### PR TITLE
docs: fix small typos

### DIFF
--- a/docs/documentation/contributing.md
+++ b/docs/documentation/contributing.md
@@ -82,7 +82,7 @@ following code style schemes based on the IDE you use:
 
 ## Thanks
 
-These guidelines were best on several sources, including
+These guidelines were based on several sources, including
 [Atom](https://github.com/atom/atom/blob/master/CONTRIBUTING.md), [PurpleBooth's
 advice](https://gist.github.com/PurpleBooth/b24679402957c63ec426) and the [Contributor
 Covenant](https://www.contributor-covenant.org/).

--- a/docs/documentation/features.md
+++ b/docs/documentation/features.md
@@ -313,7 +313,7 @@ object. Of note, particularly interesting is the `isLastAttempt` method, which c
 in your resource' status, for example, when attempting a last retry.
 
 Note, though, that reaching the retry limit won't prevent new events to be processed. New
-reconciliations will happen for new events as usual. However, if an error also ocurrs that
+reconciliations will happen for new events as usual. However, if an error also occurs that
 would normally trigger a retry, the SDK won't schedule one at this point since the retry limit
 is already reached.
 

--- a/docs/documentation/workflows.md
+++ b/docs/documentation/workflows.md
@@ -229,7 +229,7 @@ stateDiagram-v2
 - Root nodes (i.e. nodes that don't depend on any others) are reconciled first. In this example,
   DR `1` is reconciled first since it doesn't depend on others.
   After that both DR `2` and `3` are reconciled concurrently, then DR `4` once both are
-  reconciled sucessfully.
+  reconciled successfully.
 - If DR `2` had a ready condition and if it evaluated to as `false`, DR `4` would not be reconciled.
   However `1`,`2` and `3` would be.
 - If `1` had a `false` ready condition, neither `2`,`3` or `4` would be reconciled.


### PR DESCRIPTION
Hey hello there,

I'm new to the java-operator-sdk , was browsing the documentation and found some small typos. So just opened this PR. 

Thanks for this awesome operator :)