### PR TITLE
feat: update ClusterRoleBinding with default namespace ( WebPage sample )

### DIFF
--- a/sample-operators/webpage/k8s/operator.yaml
+++ b/sample-operators/webpage/k8s/operator.yaml
@@ -50,6 +50,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: webpage-operator
+  namespace: default
 roleRef:
   kind: ClusterRole
   name: webpage-operator


### PR DESCRIPTION
Although operator.yaml is mostly used by the E2E test, it would be nice to have it available for manual tests as well

Manually applying would currently result in the following error:

```
kubectl apply -f k8s/operator.yaml
serviceaccount/webpage-operator unchanged
..
...
The ClusterRoleBinding "operator-admin" is invalid: subjects[0].namespace: Required value

```