### PR TITLE
fix: standalone workflows now fail on top-level cycles

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultWorkflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultWorkflow.java
@@ -79,9 +79,9 @@ public class DefaultWorkflow<P extends HasMetadata> implements Workflow<P> {
       }
       map.put(node.getName(), node);
     }
-    if (topLevelResources.size() <= 0 ){
-      throw new IllegalStateException("Top level dependent resources set size must be bigger than 0 .");
-    }
+    if (topLevelResources.size() == 0) {
+            throw new IllegalStateException("Top level dependent resources set size must be bigger than 0 .");
+        }
     return map;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultWorkflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultWorkflow.java
@@ -79,6 +79,9 @@ public class DefaultWorkflow<P extends HasMetadata> implements Workflow<P> {
       }
       map.put(node.getName(), node);
     }
+    if (topLevelResources.size() <= 0 ){
+      throw new IllegalStateException("Top level dependent resources set size must be bigger than 0 .");
+    }
     return map;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultWorkflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultWorkflow.java
@@ -80,8 +80,9 @@ public class DefaultWorkflow<P extends HasMetadata> implements Workflow<P> {
       map.put(node.getName(), node);
     }
     if (topLevelResources.size() == 0) {
-            throw new IllegalStateException("Top level dependent resources set size must be bigger than 0 .");
-        }
+      throw new IllegalStateException(
+          "No top-level dependent resources found. This might indicate a cyclic Set of DependentResourceNode has been provided.");
+    }
     return map;
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowTest.java
@@ -14,6 +14,7 @@ import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDep
 import io.javaoperatorsdk.operator.sample.simple.TestCustomResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -23,6 +24,22 @@ import static org.mockito.Mockito.withSettings;
 class WorkflowTest {
 
   ExecutorService executorService = Executors.newCachedThreadPool();
+
+  @Test
+  void zeroTopLevelDRShouldThrowException() {
+    var dr1 = mock(DependentResource.class);
+    var dr2 = mock(DependentResource.class);
+    var dr3 = mock(DependentResource.class);
+
+    var cyclicWorkflowBuilderSetup = new WorkflowBuilder<TestCustomResource>()
+        .addDependentResource(dr1).dependsOn()
+        .addDependentResource(dr2).dependsOn(dr1)
+        .addDependentResource(dr3).dependsOn(dr2)
+        .addDependentResource(dr1).dependsOn(dr2);
+
+    assertThrows(IllegalStateException.class,
+        cyclicWorkflowBuilderSetup::build);
+  }
 
   @Test
   void calculatesTopLevelResources() {


### PR DESCRIPTION
### Workflow toplevel resoruces size
There is no point for a workflow builder with zero size toplevel resources ( A bit illogically  ).

The following builder is very strange , but it demonstrates how wrong Workflow configuration could lead for a deadlock state (topLevelResources.size() == 0, cycle detection still does not implemented )
```
  initDependentResources(kubernetesClient);
  workflow = new WorkflowBuilder<WebPage>()
        .addDependentResource(configMapDR)
        .addDependentResource(deploymentDR).dependsOn(configMapDR)
        .addDependentResource(serviceDR).dependsOn(deploymentDR)
        .addDependentResource(ingressDR).dependsOn(serviceDR)
            .addDependentResource(configMapDR).dependsOn(serviceDR)
            .build();
```

For cases where the initializations aren't logical, this exception throw can comes in
Hope is following the guidelines and the project roadmap