### PR TITLE
eventing refinements mentioned on #2012

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
@@ -365,20 +365,20 @@ public interface ConfigurationService {
   }
 
   /**
-   * If an annotation should be used so that the operator sdk can detect events from its own updates
-   * of dependent resources and then filter them.
+   * If a javaoperatorsdk.io/previous annotation should be used so that the operator sdk can detect
+   * events from its own updates of dependent resources and then filter them.
    * <p>
    * Disable this if you want to react to your own dependent resource updates
    *
    * @since 4.5.0
    */
-  default boolean previousAnnotationForDependentResources() {
+  default boolean previousAnnotationForDependentResourcesEventFiltering() {
     return true;
   }
 
   /**
-   * If the event logic should parse the resourceVersion to determine the ordering of events. This
-   * is typically not needed.
+   * If the event logic should parse the resourceVersion to determine the ordering of dependent
+   * resource events. This is typically not needed.
    * <p>
    * Disabled by default as Kubernetes does not support, and discourages, this interpretation of
    * resourceVersions. Enable only if your api server event processing seems to lag the operator
@@ -387,7 +387,7 @@ public interface ConfigurationService {
    *
    * @since 4.5.0
    */
-  default boolean parseResourceVersions() {
+  default boolean parseResourceVersionsForEventFilteringAndCaching() {
     return false;
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
@@ -364,4 +364,31 @@ public interface ConfigurationService {
     return Set.of(ConfigMap.class, Secret.class);
   }
 
+  /**
+   * If an annotation should be used so that the operator sdk can detect events from its own updates
+   * of dependent resources and then filter them.
+   * <p>
+   * Disable this if you want to react to your own dependent resource updates
+   *
+   * @since 4.5.0
+   */
+  default boolean previousAnnotationForDependentResources() {
+    return true;
+  }
+
+  /**
+   * If the event logic should parse the resourceVersion to determine the ordering of events. This
+   * is typically not needed.
+   * <p>
+   * Disabled by default as Kubernetes does not support, and discourages, this interpretation of
+   * resourceVersions. Enable only if your api server event processing seems to lag the operator
+   * logic and you want to further minimize the the amount of work done / updates issued by the
+   * operator.
+   *
+   * @since 4.5.0
+   */
+  default boolean parseResourceVersions() {
+    return false;
+  }
+
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -286,17 +286,17 @@ public class ConfigurationServiceOverrider {
       }
 
       @Override
-      public boolean previousAnnotationForDependentResources() {
+      public boolean previousAnnotationForDependentResourcesEventFiltering() {
         return previousAnnotationForDependentResources != null
             ? previousAnnotationForDependentResources
-            : super.previousAnnotationForDependentResources();
+            : super.previousAnnotationForDependentResourcesEventFiltering();
       }
 
       @Override
-      public boolean parseResourceVersions() {
+      public boolean parseResourceVersionsForEventFilteringAndCaching() {
         return parseResourceVersions != null
             ? parseResourceVersions
-            : super.parseResourceVersions();
+            : super.parseResourceVersionsForEventFilteringAndCaching();
       }
     };
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -37,6 +37,8 @@ public class ConfigurationServiceOverrider {
   private ResourceClassResolver resourceClassResolver;
   private Boolean ssaBasedCreateUpdateMatchForDependentResources;
   private Set<Class<? extends HasMetadata>> defaultNonSSAResource;
+  private Boolean previousAnnotationForDependentResources;
+  private Boolean parseResourceVersions;
 
   ConfigurationServiceOverrider(ConfigurationService original) {
     this.original = original;
@@ -158,6 +160,18 @@ public class ConfigurationServiceOverrider {
     return this;
   }
 
+  public ConfigurationServiceOverrider withPreviousAnnotationForDependentResources(
+      boolean value) {
+    this.previousAnnotationForDependentResources = value;
+    return this;
+  }
+
+  public ConfigurationServiceOverrider wihtParseResourceVersions(
+      boolean value) {
+    this.parseResourceVersions = value;
+    return this;
+  }
+
   public ConfigurationService build() {
     return new BaseConfigurationService(original.getVersion(), cloner, client) {
       @Override
@@ -269,6 +283,20 @@ public class ConfigurationServiceOverrider {
       public Set<Class<? extends HasMetadata>> defaultNonSSAResource() {
         return defaultNonSSAResource != null ? defaultNonSSAResource
             : super.defaultNonSSAResource();
+      }
+
+      @Override
+      public boolean previousAnnotationForDependentResources() {
+        return previousAnnotationForDependentResources != null
+            ? previousAnnotationForDependentResources
+            : super.previousAnnotationForDependentResources();
+      }
+
+      @Override
+      public boolean parseResourceVersions() {
+        return parseResourceVersions != null
+            ? parseResourceVersions
+            : super.parseResourceVersions();
       }
     };
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
@@ -62,6 +62,7 @@ public interface InformerConfiguration<R extends HasMetadata>
       return secondaryToPrimaryMapper;
     }
 
+    @Override
     public Optional<OnDeleteFilter<? super R>> onDeleteFilter() {
       return Optional.ofNullable(onDeleteFilter);
     }
@@ -95,12 +96,15 @@ public interface InformerConfiguration<R extends HasMetadata>
    */
   SecondaryToPrimaryMapper<R> getSecondaryToPrimaryMapper();
 
+  @Override
   Optional<OnAddFilter<? super R>> onAddFilter();
 
+  @Override
   Optional<OnUpdateFilter<? super R>> onUpdateFilter();
 
   Optional<OnDeleteFilter<? super R>> onDeleteFilter();
 
+  @Override
   Optional<GenericFilter<? super R>> genericFilter();
 
   <P extends HasMetadata> PrimaryToSecondaryMapper<P> getPrimaryToSecondaryMapper();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -211,7 +211,7 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
 
   private boolean usePreviousAnnotation(Context<P> context) {
     return context.getControllerConfiguration().getConfigurationService()
-        .previousAnnotationForDependentResources();
+        .previousAnnotationForDependentResourcesEventFiltering();
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/controller/ControllerResourceEventSource.java
@@ -32,12 +32,12 @@ public class ControllerResourceEventSource<T extends HasMetadata>
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   public ControllerResourceEventSource(Controller<T> controller) {
-    super(controller.getCRClient(), controller.getConfiguration());
+    super(controller.getCRClient(), controller.getConfiguration(), false);
     this.controller = controller;
 
     final var config = controller.getConfiguration();
     OnUpdateFilter internalOnUpdateFilter =
-        (OnUpdateFilter<T>) onUpdateFinalizerNeededAndApplied(controller.useFinalizer(),
+        onUpdateFinalizerNeededAndApplied(controller.useFinalizer(),
             config.getFinalizerName())
             .or(onUpdateGenerationAware(config.isGenerationAware()))
             .or(onUpdateMarkedForDeletion());

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -97,10 +97,10 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
     super(client.resources(configuration.getResourceClass()), configuration, parseResourceVersions);
     if (parseResourceVersions) {
       knownResourceVersions = Collections.newSetFromMap(new LinkedHashMap<>() {
-          @Override
-          protected boolean removeEldestEntry(java.util.Map.Entry<String, Boolean> eldest) {
-              return size() >= MAX_RESOURCE_VERSIONS;
-          }
+        @Override
+        protected boolean removeEldestEntry(java.util.Map.Entry<String, Boolean> eldest) {
+          return size() >= MAX_RESOURCE_VERSIONS;
+        }
       });
     } else {
       knownResourceVersions = null;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -96,11 +96,11 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
       boolean parseResourceVersions) {
     super(client.resources(configuration.getResourceClass()), configuration, parseResourceVersions);
     if (parseResourceVersions) {
-      knownResourceVersions = Collections.newSetFromMap(new LinkedHashMap<String, Boolean>() {
-        @Override
-        protected boolean removeEldestEntry(java.util.Map.Entry<String, Boolean> eldest) {
-          return size() >= MAX_RESOURCE_VERSIONS;
-        }
+      knownResourceVersions = Collections.newSetFromMap(new LinkedHashMap<>() {
+          @Override
+          protected boolean removeEldestEntry(java.util.Map.Entry<String, Boolean> eldest) {
+              return size() >= MAX_RESOURCE_VERSIONS;
+          }
       });
     } else {
       knownResourceVersions = null;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCache.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCache.java
@@ -87,8 +87,8 @@ public class TemporaryResourceCache<T extends HasMetadata> {
   private boolean isLaterResourceVersion(ResourceID resourceId, T newResource, T cachedResource) {
     try {
       if (parseResourceVersions
-          && Long.compare(Long.parseLong(newResource.getMetadata().getResourceVersion()),
-              Long.parseLong(cachedResource.getMetadata().getResourceVersion())) > 0) {
+          && Long.parseLong(newResource.getMetadata().getResourceVersion()) >
+              Long.parseLong(cachedResource.getMetadata().getResourceVersion())) {
         return true;
       }
     } catch (NumberFormatException e) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCache.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCache.java
@@ -87,8 +87,8 @@ public class TemporaryResourceCache<T extends HasMetadata> {
   private boolean isLaterResourceVersion(ResourceID resourceId, T newResource, T cachedResource) {
     try {
       if (parseResourceVersions
-          && Long.parseLong(newResource.getMetadata().getResourceVersion()) >
-              Long.parseLong(cachedResource.getMetadata().getResourceVersion())) {
+          && Long.parseLong(newResource.getMetadata().getResourceVersion()) > Long
+              .parseLong(cachedResource.getMetadata().getResourceVersion())) {
         return true;
       }
     } catch (NumberFormatException e) {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
@@ -119,7 +119,7 @@ class InformerEventSourceTest {
     informerEventSource.onUpdate(cachedDeployment, testDeployment());
 
     verify(eventHandlerMock, times(1)).handleEvent(any());
-    verify(temporaryResourceCacheMock, times(1)).removeResourceFromCache(any());
+    verify(temporaryResourceCacheMock, times(1)).onEvent(testDeployment(), false);
   }
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCacheTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCacheTest.java
@@ -91,12 +91,15 @@ class TemporaryResourceCacheTest {
   void resourceVersionParsing() {
     this.temporaryResourceCache = new TemporaryResourceCache<>(informerEventSource, true);
 
+    assertThat(temporaryResourceCache.isKnownResourceVersion(testResource())).isFalse();
+
     ConfigMap testResource = propagateTestResourceToCache();
 
     // an event with a newer version will not remove
-    temporaryResourceCache.onEvent(new ConfigMapBuilder(testResource()).editMetadata()
+    temporaryResourceCache.onEvent(new ConfigMapBuilder(testResource).editMetadata()
         .withResourceVersion("1").endMetadata().build(), false);
 
+    assertThat(temporaryResourceCache.isKnownResourceVersion(testResource)).isTrue();
     assertThat(temporaryResourceCache.getResourceFromCache(ResourceID.fromResource(testResource)))
         .isPresent();
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCacheTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/TemporaryResourceCacheTest.java
@@ -3,9 +3,11 @@ package io.javaoperatorsdk.operator.processing.event.source.informer;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
@@ -16,12 +18,16 @@ import static org.mockito.Mockito.when;
 
 class TemporaryResourceCacheTest {
 
-  public static final String RESOURCE_VERSION = "1";
+  public static final String RESOURCE_VERSION = "2";
   @SuppressWarnings("unchecked")
-  private final InformerEventSource<ConfigMap, ?> informerEventSource =
-      mock(InformerEventSource.class);
-  private final TemporaryResourceCache<ConfigMap> temporaryResourceCache =
-      new TemporaryResourceCache<>(informerEventSource);
+  private InformerEventSource<ConfigMap, ?> informerEventSource;
+  private TemporaryResourceCache<ConfigMap> temporaryResourceCache;
+
+  @BeforeEach
+  void setup() {
+    informerEventSource = mock(InformerEventSource.class);
+    temporaryResourceCache = new TemporaryResourceCache<>(informerEventSource, false);
+  }
 
   @Test
   void updateAddsTheResourceIntoCacheIfTheInformerHasThePreviousResourceVersion() {
@@ -75,7 +81,27 @@ class TemporaryResourceCacheTest {
   void removesResourceFromCache() {
     ConfigMap testResource = propagateTestResourceToCache();
 
-    temporaryResourceCache.removeResourceFromCache(testResource());
+    temporaryResourceCache.onEvent(testResource(), false);
+
+    assertThat(temporaryResourceCache.getResourceFromCache(ResourceID.fromResource(testResource)))
+        .isNotPresent();
+  }
+
+  @Test
+  void resourceVersionParsing() {
+    this.temporaryResourceCache = new TemporaryResourceCache<>(informerEventSource, true);
+
+    ConfigMap testResource = propagateTestResourceToCache();
+
+    // an event with a newer version will not remove
+    temporaryResourceCache.onEvent(new ConfigMapBuilder(testResource()).editMetadata()
+        .withResourceVersion("1").endMetadata().build(), false);
+
+    assertThat(temporaryResourceCache.getResourceFromCache(ResourceID.fromResource(testResource)))
+        .isPresent();
+
+    // anything else will remove
+    temporaryResourceCache.onEvent(testResource(), false);
 
     assertThat(temporaryResourceCache.getResourceFromCache(ResourceID.fromResource(testResource)))
         .isNotPresent();

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/CreateUpdateInformerEventSourceEventFilterIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/CreateUpdateInformerEventSourceEventFilterIT.java
@@ -31,7 +31,7 @@ class CreateUpdateInformerEventSourceEventFilterIT {
     var createdResource =
         operator.create(resource);
 
-    assertData(operator, createdResource, 1);
+    assertData(operator, createdResource, 1, 1);
 
     CreateUpdateEventFilterTestCustomResource actualCreatedResource =
         operator.get(CreateUpdateEventFilterTestCustomResource.class,
@@ -39,11 +39,11 @@ class CreateUpdateInformerEventSourceEventFilterIT {
     actualCreatedResource.getSpec().setValue("2");
     operator.replace(actualCreatedResource);
 
-    assertData(operator, actualCreatedResource, 2);
+    assertData(operator, actualCreatedResource, 2, 2);
   }
 
   static void assertData(LocallyRunOperatorExtension operator,
-      CreateUpdateEventFilterTestCustomResource resource, int executions) {
+      CreateUpdateEventFilterTestCustomResource resource, int minExecutions, int maxExecutions) {
     await()
         .atMost(Duration.ofSeconds(1))
         .until(() -> {
@@ -56,10 +56,10 @@ class CreateUpdateInformerEventSourceEventFilterIT {
               .equals(resource.getSpec().getValue());
         });
 
-    assertThat(
-        ((CreateUpdateEventFilterTestReconciler) operator.getFirstReconciler())
-            .getNumberOfExecutions())
-        .isEqualTo(executions);
+    int numberOfExecutions = ((CreateUpdateEventFilterTestReconciler) operator.getFirstReconciler())
+        .getNumberOfExecutions();
+    assertThat(numberOfExecutions).isGreaterThanOrEqualTo(minExecutions);
+    assertThat(numberOfExecutions).isLessThanOrEqualTo(maxExecutions);
   }
 
   static CreateUpdateEventFilterTestCustomResource prepareTestResource() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/PreviousAnnotationDisabledIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/PreviousAnnotationDisabledIT.java
@@ -24,7 +24,7 @@ class PreviousAnnotationDisabledIT {
     var createdResource =
         operator.create(resource);
 
-    CreateUpdateInformerEventSourceEventFilterIT.assertData(operator, createdResource, 2);
+    CreateUpdateInformerEventSourceEventFilterIT.assertData(operator, createdResource, 1, 2);
 
     CreateUpdateEventFilterTestCustomResource actualCreatedResource =
         operator.get(CreateUpdateEventFilterTestCustomResource.class,
@@ -32,7 +32,7 @@ class PreviousAnnotationDisabledIT {
     actualCreatedResource.getSpec().setValue("2");
     operator.replace(actualCreatedResource);
 
-    CreateUpdateInformerEventSourceEventFilterIT.assertData(operator, actualCreatedResource, 4);
+    CreateUpdateInformerEventSourceEventFilterIT.assertData(operator, actualCreatedResource, 2, 4);
   }
 
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/PreviousAnnotationDisabledIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/PreviousAnnotationDisabledIT.java
@@ -1,0 +1,38 @@
+package io.javaoperatorsdk.operator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+import io.javaoperatorsdk.operator.sample.createupdateeventfilter.CreateUpdateEventFilterTestCustomResource;
+import io.javaoperatorsdk.operator.sample.createupdateeventfilter.CreateUpdateEventFilterTestReconciler;
+
+class PreviousAnnotationDisabledIT {
+
+  @RegisterExtension
+  LocallyRunOperatorExtension operator =
+      LocallyRunOperatorExtension.builder()
+          .withReconciler(new CreateUpdateEventFilterTestReconciler())
+          .withConfigurationService(
+              overrider -> overrider.withPreviousAnnotationForDependentResources(false))
+          .build();
+
+  @Test
+  void updateEventReceivedAfterCreateOrUpdate() {
+    CreateUpdateEventFilterTestCustomResource resource =
+        CreateUpdateInformerEventSourceEventFilterIT.prepareTestResource();
+    var createdResource =
+        operator.create(resource);
+
+    CreateUpdateInformerEventSourceEventFilterIT.assertData(operator, createdResource, 2);
+
+    CreateUpdateEventFilterTestCustomResource actualCreatedResource =
+        operator.get(CreateUpdateEventFilterTestCustomResource.class,
+            resource.getMetadata().getName());
+    actualCreatedResource.getSpec().setValue("2");
+    operator.replace(actualCreatedResource);
+
+    CreateUpdateInformerEventSourceEventFilterIT.assertData(operator, actualCreatedResource, 4);
+  }
+
+}


### PR DESCRIPTION
provides two options
- to control if the annotation is used (to omit events that come too quickly)
- to parse the resource version (to keep the cache up-to-date and omit events if they come too slowly)

Looking for feedback on if these are the right places to introduce the configuration.