### PR TITLE
feat: Made ConfigurationServiceOverrider to accept dependent resource factory

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -80,8 +80,7 @@ public class ConfigurationServiceOverrider {
   }
 
   public ConfigurationServiceOverrider withDependentResourceFactory(DependentResourceFactory dependentResourceFactory) {
-    this.dependentResourceFactory = dependentResourceFactory != null ? dependentResourceFactory
-            : DependentResourceFactory.DEFAULT;
+    this.dependentResourceFactory = dependentResourceFactory;
     return this;
   }
 
@@ -194,7 +193,7 @@ public class ConfigurationServiceOverrider {
 
       @Override
       public DependentResourceFactory dependentResourceFactory() {
-        return dependentResourceFactory;
+        return dependentResourceFactory != null ? dependentResourceFactory : DependentResourceFactory.DEFAULT;
       }
 
       @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -79,7 +79,8 @@ public class ConfigurationServiceOverrider {
     return this;
   }
 
-  public ConfigurationServiceOverrider withDependentResourceFactory(DependentResourceFactory dependentResourceFactory) {
+  public ConfigurationServiceOverrider withDependentResourceFactory(
+      DependentResourceFactory dependentResourceFactory) {
     this.dependentResourceFactory = dependentResourceFactory;
     return this;
   }
@@ -193,7 +194,8 @@ public class ConfigurationServiceOverrider {
 
       @Override
       public DependentResourceFactory dependentResourceFactory() {
-        return dependentResourceFactory != null ? dependentResourceFactory : DependentResourceFactory.DEFAULT;
+        return dependentResourceFactory != null ? dependentResourceFactory
+            : DependentResourceFactory.DEFAULT;
       }
 
       @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
 
 @SuppressWarnings("unused")
 public class ConfigurationServiceOverrider {
@@ -39,6 +40,7 @@ public class ConfigurationServiceOverrider {
   private Set<Class<? extends HasMetadata>> defaultNonSSAResource;
   private Boolean previousAnnotationForDependentResources;
   private Boolean parseResourceVersions;
+  private DependentResourceFactory dependentResourceFactory;
 
   ConfigurationServiceOverrider(ConfigurationService original) {
     this.original = original;
@@ -74,6 +76,12 @@ public class ConfigurationServiceOverrider {
     this.minConcurrentWorkflowExecutorThreads = Utils.ensureValid(threadNumber,
         "minimum workflow execution threads", ExecutorServiceManager.MIN_THREAD_NUMBER,
         original.minConcurrentWorkflowExecutorThreads());
+    return this;
+  }
+
+  public ConfigurationServiceOverrider withDependentResourceFactory(DependentResourceFactory dependentResourceFactory) {
+    this.dependentResourceFactory = dependentResourceFactory != null ? dependentResourceFactory
+            : DependentResourceFactory.DEFAULT;
     return this;
   }
 
@@ -182,6 +190,11 @@ public class ConfigurationServiceOverrider {
       @Override
       public boolean checkCRDAndValidateLocalModel() {
         return checkCR != null ? checkCR : original.checkCRDAndValidateLocalModel();
+      }
+
+      @Override
+      public DependentResourceFactory dependentResourceFactory() {
+        return dependentResourceFactory;
       }
 
       @Override


### PR DESCRIPTION
This PR is a follow-up to #2166.

The idea here is to modify `ConfigurationServiceOverrider` to accept implementations of `DependentResourceFactory`. This modification can then be utilized by [OperatorAutoConfiguration](https://github.com/operator-framework/josdk-spring-boot-starter/blob/2ccd8556f836586d9c4d5bfbdccb6610da0f280f/starter/src/main/java/io/javaoperatorsdk/operator/springboot/starter/OperatorAutoConfiguration.java#L123) in [josdk-spring-boot-starte](https://github.com/operator-framework/josdk-spring-boot-starter/tree/main) to inject a Spring-aware `DependentResourceFactory`.

**Note**: I made this change with a high-level understanding of the codebase. I am open to learning and adjusting the changes based on suggestions if they do not align with the future plans of the library.