### PR TITLE
chore: bootstrapper maven-plugin-plugin version

### DIFF
--- a/bootstrapper-maven-plugin/pom.xml
+++ b/bootstrapper-maven-plugin/pom.xml
@@ -16,6 +16,8 @@
   <properties>
     <maven-plugin-annotations.version>3.11.0</maven-plugin-annotations.version>
     <maven-plugin-api.version>3.9.6</maven-plugin-api.version>
+    <templating-maven-plugin.version>3.0.0</templating-maven-plugin.version>
+    <maven-plugin-plugin.version>3.11.0</maven-plugin-plugin.version>
   </properties>
 
   <dependencies>
@@ -74,12 +76,15 @@
     <plugin>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-plugin-plugin</artifactId>
-      <version>3.10.2</version>
+      <version>${maven-plugin-plugin.version}</version>
+      <configuration>
+        <goalPrefix>josdk-bootstrapper</goalPrefix>
+      </configuration>
     </plugin>
     <plugin>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>templating-maven-plugin</artifactId>
-      <version>3.0.0</version>
+      <version>${templating-maven-plugin.version}</version>
       <executions>
         <execution>
           <id>filtering-java-templates</id>


### PR DESCRIPTION
fixes also missing goal prefix, see: https://maven.apache.org/guides/introduction/introduction-to-plugin-prefix-mapping.html