### PR TITLE
improve: lazy init workflow executor

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ExecutorServiceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ExecutorServiceManager.java
@@ -121,8 +121,9 @@ public class ExecutorServiceManager {
   }
 
   public void stop(Duration gracefulShutdownTimeout) {
-    try (var parallelExec = Executors.newFixedThreadPool(3)) {
+    try {
       log.debug("Closing executor");
+      var parallelExec = Executors.newFixedThreadPool(3);
       parallelExec.invokeAll(List.of(shutdown(executor, gracefulShutdownTimeout),
           shutdown(workflowExecutor, gracefulShutdownTimeout),
           shutdown(cachingExecutorService, gracefulShutdownTimeout)));

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ExecutorServiceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ExecutorServiceManager.java
@@ -128,6 +128,7 @@ public class ExecutorServiceManager {
       parallelExec.invokeAll(List.of(shutdown(executor, gracefulShutdownTimeout),
           shutdown(workflowExecutor, gracefulShutdownTimeout),
           shutdown(cachingExecutorService, gracefulShutdownTimeout)));
+      workflowExecutor = null;
       parallelExec.shutdownNow();
       started = false;
     } catch (InterruptedException e) {


### PR DESCRIPTION
If the workflows are not used in reconciliation and executor won't be initialized.