### PR TITLE
fix: using tombstones to account for rapid deletion

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -51,17 +51,17 @@ public abstract class ManagedInformerEventSource<R extends HasMetadata, P extend
 
   @Override
   public void onAdd(R resource) {
-    temporaryResourceCache.onEvent(resource, false);
+    temporaryResourceCache.onAddOrUpdateEvent(resource);
   }
 
   @Override
   public void onUpdate(R oldObj, R newObj) {
-    temporaryResourceCache.onEvent(newObj, false);
+    temporaryResourceCache.onAddOrUpdateEvent(newObj);
   }
 
   @Override
   public void onDelete(R obj, boolean deletedFinalStateUnknown) {
-    temporaryResourceCache.onEvent(obj, deletedFinalStateUnknown);
+    temporaryResourceCache.onDeleteEvent(obj, deletedFinalStateUnknown);
   }
 
   protected InformerManager<R, C> manager() {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
@@ -120,7 +120,7 @@ class InformerEventSourceTest {
     informerEventSource.onUpdate(cachedDeployment, testDeployment());
 
     verify(eventHandlerMock, times(1)).handleEvent(any());
-    verify(temporaryResourceCacheMock, times(1)).onEvent(testDeployment(), false);
+    verify(temporaryResourceCacheMock, times(1)).onAddOrUpdateEvent(testDeployment());
   }
 
   @Test


### PR DESCRIPTION
closes: #2314

If during a creation the events for both the add and the deletion occur before the resource is being added to the temporary cache, the temporary cache moves backwards in a way that may not resolve itself.

The approach here is to use tombstones to track deletions. The benefit of this approach is that it keeps the logic encapsulated to the TemporaryResourceCache. The drawback is that we're only guessing about how long to retain the tombstones.

The other approach would look more similar to event recording, which is notify the cache that a create is happening prior to when it starts so that deletions / tombstones can gathered for that specific resource.