### PR TITLE
fix: using tombstones to account for rapid deletion

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -214,6 +214,28 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   }
 
   @Override
+  protected R handleCreate(R desired, P primary, Context<P> context) {
+    var id = ResourceID.fromResource(desired);
+    try {
+      eventSource().orElseThrow().prepareForAddOrUpdate(id);
+      return super.handleCreate(desired, primary, context);
+    } finally {
+      eventSource().orElseThrow().finishAddOrUpdate(id);
+    }
+  }
+
+  @Override
+  protected R handleUpdate(R actual, R desired, P primary, Context<P> context) {
+    var id = ResourceID.fromResource(desired);
+    try {
+      eventSource().orElseThrow().prepareForAddOrUpdate(id);
+      return super.handleUpdate(actual, desired, primary, context);
+    } finally {
+      eventSource().orElseThrow().finishAddOrUpdate(id);
+    }
+  }
+
+  @Override
   protected void handleDelete(P primary, R secondary, Context<P> context) {
     if (secondary != null) {
       context.getClient().resource(secondary).delete();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -270,6 +270,14 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
     handleRecentCreateOrUpdate(Operation.ADD, resource, null);
   }
 
+  public void prepareForAddOrUpdate(ResourceID id) {
+    this.temporaryResourceCache.prepareForAddOrUpdate(id);
+  }
+
+  public void finishAddOrUpdate(ResourceID id) {
+    this.temporaryResourceCache.finshedAddOrUpdate(id);
+  }
+
   private void handleRecentCreateOrUpdate(Operation operation, R newResource, R oldResource) {
     primaryToSecondaryIndex.onAddOrUpdate(newResource);
     temporaryResourceCache.putResource(newResource, Optional.ofNullable(oldResource)


### PR DESCRIPTION
closes: #2314

uses pre/post calls, rather than time, to track tombstones. If you want to go this direction instead that seems fine, it will just push more up into the calling layers.