### PR TITLE
fix: processor concurrency issue on startup

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -401,7 +401,7 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
 
   @Override
   public synchronized void start() throws OperatorException {
-    log.debug("Stating event processor: {}", this);
+    log.debug("Starting event processor: {}", this);
     // on restart new executor service is created and needs to be set here
     executor = controllerConfiguration.getConfigurationService().getExecutorServiceManager()
         .reconcileExecutorService();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -400,7 +400,8 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
   }
 
   @Override
-  public void start() throws OperatorException {
+  public synchronized void start() throws OperatorException {
+    log.debug("Stating event processor: {}", this);
     // on restart new executor service is created and needs to be set here
     executor = controllerConfiguration.getConfigurationService().getExecutorServiceManager()
         .reconcileExecutorService();
@@ -410,6 +411,7 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
 
   private void handleAlreadyMarkedEvents() {
     for (var state : resourceStateManager.resourcesWithEventPresent()) {
+      log.debug("Handling already marked event on start. State: {}", state);
       handleMarkedEventForResource(state);
     }
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
@@ -71,7 +71,8 @@ class ReconciliationDispatcher<P extends HasMetadata> {
       throws Exception {
     P originalResource = executionScope.getResource();
     var resourceForExecution = cloneResource(originalResource);
-    log.debug("Handling dispatch for resource {}", getName(originalResource));
+    log.debug("Handling dispatch for resource name: {} namespace: {}", getName(originalResource),
+        originalResource.getMetadata().getNamespace());
 
     final var markedForDeletion = originalResource.isMarkedForDeletion();
     if (markedForDeletion && shouldNotDispatchToCleanupWhenMarkedForDeletion(originalResource)) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceState.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceState.java
@@ -111,4 +111,15 @@ class ResourceState {
         break;
     }
   }
+
+  @Override
+  public String toString() {
+    return "ResourceState{" +
+        "id=" + id +
+        ", underProcessing=" + underProcessing +
+        ", retry=" + retry +
+        ", eventing=" + eventing +
+        ", rateLimit=" + rateLimit +
+        '}';
+  }
 }


### PR DESCRIPTION
This should fix the related issue when on startup theoretically an event can be received when the processor is starting. Considering:
- On startup event received while EventProcess is not started yet
- EventProcessor starts and submits all the events (distinguished by resource id) to reconcile
- But mean while a new event is received for a certain resource that was also getting submitted by the start operation

