### PR TITLE
 fix: remove now unneeded okhttp dependency override, wrong comment 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,15 +200,6 @@
         <artifactId>operator-framework</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <!--
-            regarding the okhttp explicit version
-            see https://github.com/fabric8io/kubernetes-client/issues/4290
-            -->
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>${okhttp.version}</version>
-      </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>logging-interceptor</artifactId>
@@ -231,6 +222,7 @@
         <scope>test</scope>
       </dependency>
       <!-- Kubernetes client HTTP client implementations -->
+      <!-- Default implementation is controlled by fabric8-httpclient-impl.name property -->
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-httpclient-okhttp</artifactId>
@@ -241,7 +233,6 @@
         <artifactId>kubernetes-httpclient-vertx</artifactId>
         <version>${fabric8-client.version}</version>
       </dependency>
-      <!--            We currently only recommend using the legacy okhttp client and the vert.x-based implementation -->
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-httpclient-jdk</artifactId>


### PR DESCRIPTION
Signed-off-by: Chris Laprun <claprun@redhat.com>
