### PR TITLE
refactor: `updateMatcher` removal

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericResourceUpdater.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericResourceUpdater.java
@@ -1,29 +1,17 @@
-package io.javaoperatorsdk.operator.processing.dependent.kubernetes.updatermatcher;
+package io.javaoperatorsdk.operator.processing.dependent.kubernetes;
 
 import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.GenericKubernetesResourceMatcher;
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.ResourceUpdaterMatcher;
 
-public class GenericResourceUpdaterMatcher<R extends HasMetadata> implements
-    ResourceUpdaterMatcher<R> {
+public class GenericResourceUpdater {
 
   private static final String METADATA = "metadata";
-  private static final ResourceUpdaterMatcher<?> INSTANCE = new GenericResourceUpdaterMatcher<>();
-
-  protected GenericResourceUpdaterMatcher() {}
 
   @SuppressWarnings("unchecked")
-  public static <R extends HasMetadata> ResourceUpdaterMatcher<R> updaterMatcherFor() {
-    return (ResourceUpdaterMatcher<R>) INSTANCE;
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public R updateResource(R actual, R desired, Context<?> context) {
+  public static <R extends HasMetadata> R updateResource(R actual, R desired, Context<?> context) {
     KubernetesSerialization kubernetesSerialization =
         context.getClient().getKubernetesSerialization();
     Map<String, Object> actualMap = kubernetesSerialization.convertValue(actual, Map.class);
@@ -38,12 +26,6 @@ public class GenericResourceUpdaterMatcher<R extends HasMetadata> implements
     var clonedActual = (R) kubernetesSerialization.convertValue(actualMap, desired.getClass());
     updateLabelsAndAnnotation(clonedActual, desired);
     return clonedActual;
-  }
-
-  @Override
-  public boolean matches(R actual, R desired, Context<?> context) {
-    return GenericKubernetesResourceMatcher.match(desired, actual,
-        false, false, context).matched();
   }
 
   public static <K extends HasMetadata> void updateLabelsAndAnnotation(K actual, K desired) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -38,7 +38,6 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   private final boolean garbageCollected = this instanceof GarbageCollected;
   private final boolean usingCustomResourceUpdateMatcher = this instanceof ResourceUpdaterMatcher;
 
-  private final boolean clustered;
   private KubernetesDependentResourceConfig<R> kubernetesDependentResourceConfig;
 
   public KubernetesDependentResource(Class<R> resourceType) {
@@ -53,7 +52,6 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
   public void configureWith(KubernetesDependentResourceConfig<R> config) {
     this.kubernetesDependentResourceConfig = config;
   }
-
 
   @SuppressWarnings("unused")
   public R create(R desired, P primary, Context<P> context) {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcherTest.java
@@ -148,8 +148,8 @@ class GenericKubernetesResourceMatcherTest {
         .addNewImagePullSecret("imagePullSecret3")
         .build();
 
-      assertThat(GenericKubernetesResourceMatcher.match(desired, actual, false, false, context)
-              .matched()).isTrue();
+    assertThat(GenericKubernetesResourceMatcher.match(desired, actual, false, false, context)
+        .matched()).isTrue();
   }
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcherTest.java
@@ -13,15 +13,13 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentStatusBuilder;
 import io.javaoperatorsdk.operator.MockKubernetesClient;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.dependent.Matcher;
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.updatermatcher.GenericResourceUpdaterMatcher;
 
 import static io.javaoperatorsdk.operator.processing.dependent.kubernetes.GenericKubernetesResourceMatcher.match;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings({"unchecked", "rawtypes"})
+@SuppressWarnings({"unchecked"})
 class GenericKubernetesResourceMatcherTest {
 
   private static final Context context = mock(Context.class);
@@ -29,7 +27,7 @@ class GenericKubernetesResourceMatcherTest {
   Deployment actual = createDeployment();
   Deployment desired = createDeployment();
   TestDependentResource dependentResource = new TestDependentResource(desired);
-  Matcher matcher = GenericKubernetesResourceMatcher.matcherFor(dependentResource);
+
 
   @BeforeAll
   static void setUp() {
@@ -39,15 +37,17 @@ class GenericKubernetesResourceMatcherTest {
 
   @Test
   void matchesTrivialCases() {
-    assertThat(matcher.match(actual, null, context).matched()).isTrue();
-    assertThat(matcher.match(actual, null, context).computedDesired()).isPresent();
-    assertThat(matcher.match(actual, null, context).computedDesired()).contains(desired);
+    assertThat(GenericKubernetesResourceMatcher.match(desired, actual, context).matched()).isTrue();
+    assertThat(GenericKubernetesResourceMatcher.match(desired, actual, context).computedDesired())
+        .isPresent();
+    assertThat(GenericKubernetesResourceMatcher.match(desired, actual, context).computedDesired())
+        .contains(desired);
   }
 
   @Test
   void matchesAdditiveOnlyChanges() {
     actual.getSpec().getTemplate().getMetadata().getLabels().put("new-key", "val");
-    assertThat(matcher.match(actual, null, context).matched())
+    assertThat(GenericKubernetesResourceMatcher.match(desired, actual, context).matched())
         .withFailMessage("Additive changes should not cause a mismatch by default")
         .isTrue();
   }
@@ -64,7 +64,9 @@ class GenericKubernetesResourceMatcherTest {
   @Test
   void doesNotMatchRemovedValues() {
     actual = createDeployment();
-    assertThat(matcher.match(actual, createPrimary("removed"), context).matched())
+    assertThat(GenericKubernetesResourceMatcher
+        .match(dependentResource.desired(createPrimary("removed"), null), actual, context)
+        .matched())
         .withFailMessage("Removing values in metadata should lead to a mismatch")
         .isFalse();
   }
@@ -73,7 +75,7 @@ class GenericKubernetesResourceMatcherTest {
   void doesNotMatchChangedValues() {
     actual = createDeployment();
     actual.getSpec().setReplicas(2);
-    assertThat(matcher.match(actual, null, context).matched())
+    assertThat(GenericKubernetesResourceMatcher.match(desired, actual, context).matched())
         .withFailMessage("Should not have matched because values have changed")
         .isFalse();
   }
@@ -82,7 +84,7 @@ class GenericKubernetesResourceMatcherTest {
   void ignoreStatus() {
     actual = createDeployment();
     actual.setStatus(new DeploymentStatusBuilder().withReadyReplicas(1).build());
-    assertThat(matcher.match(actual, null, context).matched())
+    assertThat(GenericKubernetesResourceMatcher.match(desired, actual, context).matched())
         .withFailMessage("Should ignore status in actual")
         .isTrue();
   }
@@ -146,8 +148,8 @@ class GenericKubernetesResourceMatcherTest {
         .addNewImagePullSecret("imagePullSecret3")
         .build();
 
-    final var matcher = GenericResourceUpdaterMatcher.<ServiceAccount>updaterMatcherFor();
-    assertThat(matcher.matches(actual, desired, context)).isTrue();
+      assertThat(GenericKubernetesResourceMatcher.match(desired, actual, false, false, context)
+              .matched()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Currently there wast just one `UpdateMatcher` implementation, while it was explicitly in the code that SSA is handled differently.

This PR removes the updateMatcher concept, and makes it explicit that SSA uses the ssa matcher and SSA updater, and also the same holds for the generic matcher and updater.

While I don't disagree with the updateMatcher concept there will be no other combinations than these two.