### PR TITLE
Use SSA to create namespace and infra for integration test

### DIFF
--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/AbstractOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/AbstractOperatorExtension.java
@@ -157,11 +157,11 @@ public abstract class AbstractOperatorExtension implements HasKubernetesClient,
         .resource(
             new NamespaceBuilder().withMetadata(new ObjectMetaBuilder().withName(namespace).build())
                 .build())
-        .create();
+        .serverSideApply();
 
     kubernetesClient
         .resourceList(infrastructure)
-        .createOrReplace();
+        .serverSideApply();
     kubernetesClient
         .resourceList(infrastructure)
         .waitUntilReady(infrastructureTimeout.toMillis(), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Use server-side apply to create the namespace used for integration test. This, combined with `withNamespaceNameSupplier`, allows the use of a preconfigured namespace for integration tests. We need this because in our particular case some third-party infrastructure cannot be configured at the time of namespace creation and must be set up in advance.