### PR TITLE
Fix typos in comments and error messages

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
@@ -392,7 +392,7 @@ public interface ConfigurationService {
    * <p>
    * Disabled by default as Kubernetes does not support, and discourages, this interpretation of
    * resourceVersions. Enable only if your api server event processing seems to lag the operator
-   * logic and you want to further minimize the the amount of work done / updates issued by the
+   * logic and you want to further minimize the amount of work done / updates issued by the
    * operator.
    *
    * @since 4.5.0

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/TypeParameterResolver.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/TypeParameterResolver.java
@@ -33,8 +33,8 @@ class TypeParameterResolver {
    *        can be passed.
    * @param declaredType Class or Interface which extends or implements the interestedClass, and the
    *        interest is getting the actual declared type is used.
-   * @return the type of the parameter if it can be resolved from the the given declareType,
-   *         otherwise it returns null
+   * @return the type of the parameter if it can be resolved from the given declareType, otherwise
+   *         it returns null
    */
   public TypeMirror resolve(Types typeUtils, DeclaredType declaredType) {
     final var chain = findChain(typeUtils, declaredType);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/sample/standalonedependent/StandaloneDependentTestReconciler.java
@@ -43,7 +43,7 @@ public class StandaloneDependentTestReconciler
 
     if (deployment.get().getSpec().getReplicas() != primary.getSpec().getReplicaCount()) {
       // see https://github.com/operator-framework/java-operator-sdk/issues/924
-      throw new IllegalStateException("Something went wrong withe the cache mechanism.");
+      throw new IllegalStateException("Something went wrong with the cache mechanism.");
     }
     return UpdateControl.noUpdate();
   }


### PR DESCRIPTION
I found some typos and "the the" in comments and error messages.
