### PR TITLE
improve: cleaner throws Exception

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Cleaner.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Cleaner.java
@@ -27,6 +27,6 @@ public interface Cleaner<P extends HasMetadata> {
    *         that it can be safely deleted.
    * @see DeleteControl#noFinalizerRemoval()
    */
-  DeleteControl cleanup(P resource, Context<P> context);
+  DeleteControl cleanup(P resource, Context<P> context) throws Exception;
 
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -189,7 +189,7 @@ public class Controller<P extends HasMetadata>
             }
 
             @Override
-            public DeleteControl execute() {
+            public DeleteControl execute() throws Exception {
               initContextIfNeeded(resource, context);
               WorkflowCleanupResult workflowCleanupResult = null;
 


### PR DESCRIPTION
Reconciler has this in the signature too. It is completely fine to throw exception
from this method.

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
