### PR TITLE
feat: print diff resource as yaml

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -104,9 +104,9 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     removeIrrelevantValues(desiredMap);
 
     if (LoggingUtils.isNotSensitiveResource(desired)) {
-      var actualYml = objectMapper.asYaml(prunedActual);
-      var desiredYml = objectMapper.asYaml(desiredMap);
-      log.debug("Pruned actual: \n {} \n desired: \n {} ", actualYml, desiredYml);
+      var actualYaml = objectMapper.asYaml(prunedActual);
+      var desiredYaml = objectMapper.asYaml(desiredMap);
+      log.debug("Pruned actual: \n {} \n desired: \n {} ", actualYaml, desiredYaml);
     }
 
     return prunedActual.equals(desiredMap);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -114,9 +114,9 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     if (log.isDebugEnabled()) {
       var actualYaml = serialization.asYaml(prunedActualMap);
       var desiredYaml = serialization.asYaml(desiredMap);
-      log.debug("Pruned actual: \n {} \n desired: \n {} ", actualYaml, desiredYaml);
+      log.debug("Pruned actual yaml: \n {} \n desired yaml: \n {} ", actualYaml, desiredYaml);
     } else {
-      log.debug("Pruned actual: \n {} \n desired: \n {} ", prunedActualMap, desiredMap);
+      log.debug("Pruned actual map: \n {} \n desired map: \n {} ", prunedActualMap, desiredMap);
     }
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -110,7 +110,8 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     return prunedActual.equals(desiredMap);
   }
 
-  private void logDiff(Map<String, Object> prunedActualMap, Map<String, Object> desiredMap, KubernetesSerialization serialization) {
+  private void logDiff(Map<String, Object> prunedActualMap, Map<String, Object> desiredMap,
+      KubernetesSerialization serialization) {
     if (log.isDebugEnabled()) {
       var actualYaml = serialization.asYaml(prunedActualMap);
       var desiredYaml = serialization.asYaml(desiredMap);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -104,7 +104,9 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     removeIrrelevantValues(desiredMap);
 
     if (LoggingUtils.isNotSensitiveResource(desired)) {
-      log.debug("Pruned actual: \n {} \n desired: \n {} ", prunedActual, desiredMap);
+      var actualYml = objectMapper.asYaml(prunedActual);
+      var desiredYml = objectMapper.asYaml(desiredMap);
+      log.debug("Pruned actual: \n {} \n desired: \n {} ", actualYml, desiredYml);
     }
 
     return prunedActual.equals(desiredMap);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -116,8 +116,6 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
       var actualYaml = serialization.asYaml(prunedActualMap);
       var desiredYaml = serialization.asYaml(desiredMap);
       log.debug("Pruned actual yaml: \n {} \n desired yaml: \n {} ", actualYaml, desiredYaml);
-    } else {
-      log.debug("Pruned actual map: \n {} \n desired map: \n {} ", prunedActualMap, desiredMap);
     }
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -104,12 +104,20 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     removeIrrelevantValues(desiredMap);
 
     if (LoggingUtils.isNotSensitiveResource(desired)) {
-      var actualYaml = objectMapper.asYaml(prunedActual);
-      var desiredYaml = objectMapper.asYaml(desiredMap);
-      log.debug("Pruned actual: \n {} \n desired: \n {} ", actualYaml, desiredYaml);
+      logDiff(prunedActual, desiredMap, objectMapper);
     }
 
     return prunedActual.equals(desiredMap);
+  }
+
+  private void logDiff(Map<String, Object> prunedActualMap, Map<String, Object> desiredMap, KubernetesSerialization serialization) {
+    if (log.isDebugEnabled()) {
+      var actualYaml = serialization.asYaml(prunedActualMap);
+      var desiredYaml = serialization.asYaml(desiredMap);
+      log.debug("Pruned actual: \n {} \n desired: \n {} ", actualYaml, desiredYaml);
+    } else {
+      log.debug("Pruned actual: \n {} \n desired: \n {} ", prunedActualMap, desiredMap);
+    }
   }
 
   /**


### PR DESCRIPTION
resolved: #2492 

## AS-IS

Output diff data in text format

```
{data={key1=val1}, metadata={ownerReferences=[{name=kube-root-ca.crt, uid=1ef74cb4-dbbd-45ef-9caf-aa76186594ea, apiVersion=v1, kind=ConfigMap}]}}

{metadata={ownerReferences=[{apiVersion=v1, kind=ConfigMap, name=kube-root-ca.crt, uid=1ef74cb4-dbbd-45ef-9caf-aa76186594ea}]}, data={key1=different value}}
```

- problem : It's difficult to compare

## TO-BE

Output diff data in yml format

```yml
data:
  key1: "val1"
metadata:
  ownerReferences:
  - name: "kube-root-ca.crt"
    uid: "1ef74cb4-dbbd-45ef-9caf-aa76186594ea"
    apiVersion: "v1"
    kind: "ConfigMap"
 
 ---
metadata:
  ownerReferences:
  - apiVersion: "v1"
    kind: "ConfigMap"
    name: "kube-root-ca.crt"
    uid: "1ef74cb4-dbbd-45ef-9caf-aa76186594ea"
data:
  key1: "different value"
```

If the user sorts fields through Jackson settings `.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)`
it will look much better because the keys will be displayed in sorted order.

---

