### PR TITLE
feat: improve diff logging

### DIFF
--- a/operator-framework-core/pom.xml
+++ b/operator-framework-core/pom.xml
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/operator-framework-core/pom.xml
+++ b/operator-framework-core/pom.xml
@@ -15,6 +15,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.github.java-diff-utils</groupId>
+      <artifactId>java-diff-utils</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
       <exclusions>
@@ -58,6 +62,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -120,11 +120,15 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
 
   private String getDiff(Map<String, Object> prunedActualMap, Map<String, Object> desiredMap,
       KubernetesSerialization serialization) {
-    var actualLines = serialization.asYaml(sortMap(prunedActualMap)).lines().toList();
-    var desiredLines = serialization.asYaml(sortMap(desiredMap)).lines().toList();
+    var actualYaml = serialization.asYaml(sortMap(prunedActualMap));
+    var desiredYaml = serialization.asYaml(sortMap(desiredMap));
+    if (log.isTraceEnabled()) {
+      log.trace("Pruned actual resource: \n{} \ndesired resource: \n{} ", actualYaml, desiredYaml);
+    }
 
-    var patch = DiffUtils.diff(actualLines, desiredLines);
-    List<String> unifiedDiff = DiffUtils.generateUnifiedDiff("", "", actualLines, patch, 1);
+    var patch = DiffUtils.diff(actualYaml.lines().toList(), desiredYaml.lines().toList());
+    List<String> unifiedDiff =
+        DiffUtils.generateUnifiedDiff("", "", actualYaml.lines().toList(), patch, 1);
     return String.join("\n", unifiedDiff);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -124,7 +124,7 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     var desiredLines = serialization.asYaml(sortMap(desiredMap)).lines().toList();
 
     var patch = DiffUtils.diff(actualLines, desiredLines);
-    List<String> unifiedDiff = DiffUtils.generateUnifiedDiff("", "", actualLines, patch, 0);
+    List<String> unifiedDiff = DiffUtils.generateUnifiedDiff("", "", actualLines, patch, 1);
     return String.join("\n", unifiedDiff);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -105,7 +105,9 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
 
     removeIrrelevantValues(desiredMap);
 
-    if (LoggingUtils.isNotSensitiveResource(desired)) {
+    var matches = prunedActual.equals(desiredMap);
+    
+    if (!matches && LoggingUtils.isNotSensitiveResource(desired)) {
       var diff = getDiff(prunedActual, desiredMap, objectMapper);
       if (diff != null) {
           log.debug("Diff between actual and desired state for resource: {} with name: {} in namespace: {} is: \n{}", 
@@ -113,7 +115,7 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
       }
     }
 
-    return prunedActual.equals(desiredMap);
+    return matches;
   }
 
   private String getDiff(Map<String, Object> prunedActualMap, Map<String, Object> desiredMap,

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -109,7 +109,7 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     
     if (!matches && LoggingUtils.isNotSensitiveResource(desired)) {
       var diff = getDiff(prunedActual, desiredMap, objectMapper);
-      if (diff != null) {
+      if (log.isDebugEnabled()) {
           log.debug("Diff between actual and desired state for resource: {} with name: {} in namespace: {} is: \n{}", 
                   actual.getKind(), actual.getMetadata().getName(), actual.getMetadata().getNamespace(), diff);
       }
@@ -120,15 +120,12 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
 
   private String getDiff(Map<String, Object> prunedActualMap, Map<String, Object> desiredMap,
                          KubernetesSerialization serialization) {
-    if (log.isDebugEnabled()) {
-      var actualLines = serialization.asYaml(sortMap(prunedActualMap)).lines().toList();
-      var desiredLines = serialization.asYaml(sortMap(desiredMap)).lines().toList();
+    var actualLines = serialization.asYaml(sortMap(prunedActualMap)).lines().toList();
+    var desiredLines = serialization.asYaml(sortMap(desiredMap)).lines().toList();
 
-      var patch = DiffUtils.diff(actualLines, desiredLines);
-      List<String> unifiedDiff = DiffUtils.generateUnifiedDiff("", "", actualLines, patch, 0);
-      return unifiedDiff.isEmpty() ? null : String.join("\n", unifiedDiff);
-    }
-    return null;
+    var patch = DiffUtils.diff(actualLines, desiredLines);
+    List<String> unifiedDiff = DiffUtils.generateUnifiedDiff("", "", actualLines, patch, 0);
+    return String.join("\n", unifiedDiff);
   }
 
   @SuppressWarnings("unchecked")

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -107,14 +107,12 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
 
     var matches = prunedActual.equals(desiredMap);
 
-    if (!matches && LoggingUtils.isNotSensitiveResource(desired)) {
+    if (!matches && log.isDebugEnabled() && LoggingUtils.isNotSensitiveResource(desired)) {
       var diff = getDiff(prunedActual, desiredMap, objectMapper);
-      if (log.isDebugEnabled()) {
-        log.debug(
-            "Diff between actual and desired state for resource: {} with name: {} in namespace: {} is: \n{}",
-            actual.getKind(), actual.getMetadata().getName(), actual.getMetadata().getNamespace(),
-            diff);
-      }
+      log.debug(
+          "Diff between actual and desired state for resource: {} with name: {} in namespace: {} is: \n{}",
+          actual.getKind(), actual.getMetadata().getName(), actual.getMetadata().getNamespace(),
+          diff);
     }
 
     return matches;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -136,7 +136,7 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
   }
 
   @SuppressWarnings("unchecked")
-  private Map<String, Object> sortMap(Map<String, Object> map) {
+  Map<String, Object> sortMap(Map<String, Object> map) {
     List<String> sortedKeys = new ArrayList<>(map.keySet());
     Collections.sort(sortedKeys);
 
@@ -144,10 +144,9 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     for (String key : sortedKeys) {
       Object value = map.get(key);
       if (value instanceof Map) {
-        Map<String, Object> nestedMap = (Map<String, Object>) value;
-        sortedMap.put(key, sortMap(nestedMap));
+        sortedMap.put(key, sortMap((Map<String, Object>) value));
       } else if (value instanceof List) {
-        sortedMap.put(key, sortList((List<?>) value));
+        sortedMap.put(key, sortListItems((List<Object>) value));
       } else {
         sortedMap.put(key, value);
       }
@@ -156,14 +155,13 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
   }
 
   @SuppressWarnings("unchecked")
-  private List<?> sortList(List<?> list) {
+  List<Object> sortListItems(List<Object> list) {
     List<Object> sortedList = new ArrayList<>();
     for (Object item : list) {
       if (item instanceof Map) {
-        Map<String, Object> mapItem = (Map<String, Object>) item;
-        sortedList.add(sortMap(mapItem));
+        sortedList.add(sortMap((Map<String, Object>) item));
       } else if (item instanceof List) {
-        sortedList.add(sortList((List<?>) item));
+        sortedList.add(sortListItems((List<Object>) item));
       } else {
         sortedList.add(item);
       }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.assertj.core.util.diff.DiffUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +25,9 @@ import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.LoggingUtils;
+
+import com.github.difflib.DiffUtils;
+import com.github.difflib.UnifiedDiffUtils;
 
 /**
  * Matches the actual state on the server vs the desired state. Based on the managedFields of SSA.
@@ -123,12 +125,13 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     var actualYaml = serialization.asYaml(sortMap(prunedActualMap));
     var desiredYaml = serialization.asYaml(sortMap(desiredMap));
     if (log.isTraceEnabled()) {
-      log.trace("Pruned actual resource: \n{} \ndesired resource: \n{} ", actualYaml, desiredYaml);
+      log.trace("Pruned actual resource: \n {} \ndesired resource: \n {} ", actualYaml,
+          desiredYaml);
     }
 
     var patch = DiffUtils.diff(actualYaml.lines().toList(), desiredYaml.lines().toList());
     List<String> unifiedDiff =
-        DiffUtils.generateUnifiedDiff("", "", actualYaml.lines().toList(), patch, 1);
+        UnifiedDiffUtils.generateUnifiedDiff("", "", actualYaml.lines().toList(), patch, 1);
     return String.join("\n", unifiedDiff);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -106,12 +106,14 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
     removeIrrelevantValues(desiredMap);
 
     var matches = prunedActual.equals(desiredMap);
-    
+
     if (!matches && LoggingUtils.isNotSensitiveResource(desired)) {
       var diff = getDiff(prunedActual, desiredMap, objectMapper);
       if (log.isDebugEnabled()) {
-          log.debug("Diff between actual and desired state for resource: {} with name: {} in namespace: {} is: \n{}", 
-                  actual.getKind(), actual.getMetadata().getName(), actual.getMetadata().getNamespace(), diff);
+        log.debug(
+            "Diff between actual and desired state for resource: {} with name: {} in namespace: {} is: \n{}",
+            actual.getKind(), actual.getMetadata().getName(), actual.getMetadata().getNamespace(),
+            diff);
       }
     }
 
@@ -119,7 +121,7 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
   }
 
   private String getDiff(Map<String, Object> prunedActualMap, Map<String, Object> desiredMap,
-                         KubernetesSerialization serialization) {
+      KubernetesSerialization serialization) {
     var actualLines = serialization.asYaml(sortMap(prunedActualMap)).lines().toList();
     var desiredLines = serialization.asYaml(sortMap(desiredMap)).lines().toList();
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcherTest.java
@@ -1,5 +1,8 @@
 package io.javaoperatorsdk.operator.processing.dependent.kubernetes;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -121,4 +124,47 @@ class SSABasedGenericKubernetesResourceMatcherTest {
         fileName);
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  void sortListItemsTest() {
+    Map<String, Object> nestedMap1 = new HashMap<>();
+    nestedMap1.put("z", 26);
+    nestedMap1.put("y", 25);
+
+    Map<String, Object> nestedMap2 = new HashMap<>();
+    nestedMap2.put("b", 26);
+    nestedMap2.put("c", 25);
+    nestedMap2.put("a", 24);
+
+    List<Object> unsortedListItems = Arrays.asList(1, nestedMap1, nestedMap2);
+    List<Object> sortedListItems = matcher.sortListItems(unsortedListItems);
+
+    assertThat(sortedListItems).element(0).isEqualTo(1);
+
+    Map<String, Object> sortedNestedMap1 = (Map<String, Object>) sortedListItems.get(1);
+    assertThat(sortedNestedMap1.keySet()).containsExactly("y", "z");
+
+    Map<String, Object> sortedNestedMap2 = (Map<String, Object>) sortedListItems.get(2);
+    assertThat(sortedNestedMap2.keySet()).containsExactly("a", "b", "c");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testSortMapWithNestedMap() {
+    Map<String, Object> nestedMap = new HashMap<>();
+    nestedMap.put("z", 26);
+    nestedMap.put("y", 25);
+
+    Map<String, Object> unsortedMap = new HashMap<>();
+    unsortedMap.put("b", nestedMap);
+    unsortedMap.put("a", 1);
+    unsortedMap.put("c", 2);
+
+    Map<String, Object> sortedMap = matcher.sortMap(unsortedMap);
+
+    assertThat(sortedMap.keySet()).containsExactly("a", "b", "c");
+
+    Map<String, Object> sortedNestedMap = (Map<String, Object>) sortedMap.get("b");
+    assertThat(sortedNestedMap.keySet()).containsExactly("y", "z");
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <caffeine.version>3.1.8</caffeine.version>
     <mustache.version>0.9.11</mustache.version>
     <commons.io.version>2.16.1</commons.io.version>
+    <java.diff.version>4.12</java.diff.version>
 
     <fmt-maven-plugin.version>2.11</fmt-maven-plugin.version>
     <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
@@ -161,6 +162,11 @@
         <version>${mokito.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.github.java-diff-utils</groupId>
+        <artifactId>java-diff-utils</artifactId>
+        <version>${java.diff.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
Based on [this](https://github.com/operator-framework/java-operator-sdk/pull/2542#issuecomment-2387669854) comment.

Diff is calculated and printed only if there is a mismatch between actual and desired state and logger is enabled for the debug level. Here is the sample output:
 
```
2024-10-02 16:38:42,233 1 i.j.o.p.d.k.SSABasedGenericKubernetesResourceMatcher [DEBUG] Diff between actual and desired state for resource: ConfigMap with name: test1 in namespace: default is: 
--- 
+++ 
@@ -2,3 +2,3 @@
 data:
-  key1: "val1"
+  key1: "different value"
 metadata:

```