### PR TITLE
fix: docs double header in migration docs

### DIFF
--- a/docs/content/en/docs/migration/v2-migration.md
+++ b/docs/content/en/docs/migration/v2-migration.md
@@ -1,11 +1,8 @@
 ---
 title: Migrating from v1 to v2
-description: Migrating from v1 to v2
 layout: docs
 permalink: /docs/v2-migration
 ---
-
-# Migrating from v1 to v2
 
 Version 2 of the framework introduces improvements, features and breaking changes for the APIs both
 internal and user facing ones. The migration should be however trivial in most of the cases. For

--- a/docs/content/en/docs/migration/v3-1-migration.md
+++ b/docs/content/en/docs/migration/v3-1-migration.md
@@ -1,11 +1,8 @@
 ---
 title: Migrating from v3 to v3.1
-description: Migrating from v3 to v3.1
 layout: docs
 permalink: /docs/v3-1-migration
 ---
-
-# Migrating from v3 to v3.1
 
 ## ReconciliationMaxInterval Annotation has been renamed to MaxReconciliationInterval
 

--- a/docs/content/en/docs/migration/v3-migration.md
+++ b/docs/content/en/docs/migration/v3-migration.md
@@ -1,11 +1,8 @@
 ---
 title: Migrating from v2 to v3
-description: Migrating from v2 to v3
 layout: docs
 permalink: /docs/v3-migration
 ---
-
-# Migrating from v2 to v3
 
 Version 3 introduces some breaking changes to APIs, however the migration to these changes should be trivial.
 

--- a/docs/content/en/docs/migration/v4-3-migration.md
+++ b/docs/content/en/docs/migration/v4-3-migration.md
@@ -1,11 +1,8 @@
 ---
 title: Migrating from v4.2 to v4.3
-description: Migrating from v4.2 to v4.3
 layout: docs
 permalink: /docs/v4-3-migration
 ---
-
-# Migrating from v4.2 to v4.3
 
 ## Condition API Change
 

--- a/docs/content/en/docs/migration/v4-4-migration.md
+++ b/docs/content/en/docs/migration/v4-4-migration.md
@@ -1,11 +1,8 @@
 ---
 title: Migrating from v4.3 to v4.4
-description: Migrating from v4.3 to v4.4
 layout: docs
 permalink: /docs/v4-4-migration
 ---
-
-# Migrating from v4.3 to v4.4
 
 ## API changes
 

--- a/docs/content/en/docs/migration/v4-5-migration.md
+++ b/docs/content/en/docs/migration/v4-5-migration.md
@@ -1,11 +1,8 @@
 ---
 title: Migrating from v4.4 to v4.5
-description: Migrating from v4.4 to v4.5
 layout: docs
 permalink: /docs/v4-5-migration
 ---
-
-# Migrating from v4.4 to v4.5
 
 Version 4.5 introduces improvements related to event handling for Dependent Resources, more precisely the
 [caching and event handling](https://javaoperatorsdk.io/docs/dependent-resources#caching-and-event-handling-in-kubernetesdependentresource)


### PR DESCRIPTION
The explicit title caused to show the title in double