### PR TITLE
refactor: move spotless to a profile active only in the root directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,38 +314,6 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <configuration>
-          <pom>
-            <includes>
-              <include>pom.xml</include>
-              <include>./**/pom.xml</include>
-            </includes>
-            <sortPom>
-              <expandEmptyElements>false</expandEmptyElements>
-            </sortPom>
-          </pom>
-          <java>
-            <eclipse>
-              <file>contributing/eclipse-google-style.xml</file>
-            </eclipse>
-            <importOrder>
-              <file>contributing/eclipse.importorder</file>
-            </importOrder>
-            <removeUnusedImports/>
-          </java>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>apply</goal>
-            </goals>
-            <phase>compile</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
@@ -362,6 +330,50 @@
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <id>spotless</id>
+      <activation>
+        <file>
+          <exists>contributing</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <configuration>
+              <pom>
+                <includes>
+                  <include>pom.xml</include>
+                  <include>./**/pom.xml</include>
+                </includes>
+                <sortPom>
+                  <expandEmptyElements>false</expandEmptyElements>
+                </sortPom>
+              </pom>
+              <java>
+                <eclipse>
+                  <file>contributing/eclipse-google-style.xml</file>
+                </eclipse>
+                <importOrder>
+                  <file>contributing/eclipse.importorder</file>
+                </importOrder>
+                <removeUnusedImports/>
+              </java>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>apply</goal>
+                </goals>
+                <phase>compile</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>integration-tests</id>
       <build>


### PR DESCRIPTION
This allows running maven in submodules, for instance to run only some tests.