### PR TITLE
fix: add clean up of applied CRDs after tests

### DIFF
--- a/sample-operators/tomcat-operator/src/test/java/io/javaoperatorsdk/operator/sample/TomcatOperatorE2E.java
+++ b/sample-operators/tomcat-operator/src/test/java/io/javaoperatorsdk/operator/sample/TomcatOperatorE2E.java
@@ -117,6 +117,11 @@ class TomcatOperatorE2E {
         throw new AssertionError(ex);
       }
     });
+
+    log.info("Deleting test Tomcat object: {}", tomcat);
+    tomcatClient.inNamespace(operator.getNamespace()).resource(tomcat).delete();
+    log.info("Deleting test Webapp object: {}", webapp1);
+    webappClient.inNamespace(operator.getNamespace()).resource(webapp1).delete();
   }
 
 }


### PR DESCRIPTION
Before:

```
$ mvn clean install -Pintegration-tests
...

$ kubectl get crds | wc -l
83
```

With this PR:

```
$ mvn clean install -Pintegration-tests
...

$ kubectl get crds | wc -l
No resources found
0
```