### PR TITLE
Fix apiVersion match for standard K8s resources

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
@@ -83,9 +83,10 @@ public class Mappers {
 
   public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromOwnerReferences(
       String apiVersion, String kind, boolean clusterScope) {
+    String correctApiVersion = apiVersion.startsWith("/") ? apiVersion.substring(1) : apiVersion;
     return resource ->
         resource.getMetadata().getOwnerReferences().stream()
-            .filter(r -> r.getKind().equals(kind) && r.getApiVersion().equals(apiVersion))
+            .filter(r -> r.getKind().equals(kind) && r.getApiVersion().equals(correctApiVersion))
             .map(or -> ResourceID.fromOwnerReference(resource, or, clusterScope))
             .collect(Collectors.toSet());
   }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/MappersTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/MappersTest.java
@@ -30,6 +30,31 @@ class MappersTest {
   }
 
   @Test
+  void secondaryToPrimaryMapperFromOwnerReferenceWhereGroupIdIsEmpty() {
+    var primary =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("test")
+            .withNamespace("default")
+            .endMetadata()
+            .build();
+    primary.getMetadata().setUid(UUID.randomUUID().toString());
+    var secondary =
+        new ConfigMapBuilder()
+            .withMetadata(
+                new ObjectMetaBuilder()
+                    .withName("test1")
+                    .withNamespace(primary.getMetadata().getNamespace())
+                    .build())
+            .build();
+    secondary.addOwnerReference(primary);
+
+    var res = Mappers.fromOwnerReferences(ConfigMap.class).toPrimaryResourceIDs(secondary);
+
+    assertThat(res).contains(ResourceID.fromResource(primary));
+  }
+
+  @Test
   void secondaryToPrimaryMapperFromOwnerReferenceFiltersByType() {
     var primary = TestUtils.testCustomResource();
     primary.getMetadata().setUid(UUID.randomUUID().toString());


### PR DESCRIPTION
The HasMetadata.getApiVersion(primaryResourceType) method return "/v1" for the ConfigMap type. Since the K8s owner reference uses "v1" instead, the secondary resource of a primary ConfigMap will not be tracked correctly.

Proposed fix for #2723