### PR TITLE
improve: remove seamless type change

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesDependentResource.java
@@ -9,7 +9,7 @@ import io.javaoperatorsdk.operator.processing.GroupVersionKind;
 public class GenericKubernetesDependentResource<P extends HasMetadata>
     extends KubernetesDependentResource<GenericKubernetesResource, P> {
 
-  private final GroupVersionKindPlural groupVersionKind;
+  private final GroupVersionKind groupVersionKind;
 
   public GenericKubernetesDependentResource(GroupVersionKind groupVersionKind) {
     this(GroupVersionKindPlural.from(groupVersionKind));
@@ -27,7 +27,7 @@ public class GenericKubernetesDependentResource<P extends HasMetadata>
   }
 
   @SuppressWarnings("unused")
-  public GroupVersionKindPlural getGroupVersionKind() {
+  public GroupVersionKind getGroupVersionKind() {
     return groupVersionKind;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesDependentResource.java
@@ -20,6 +20,7 @@ public class GenericKubernetesDependentResource<P extends HasMetadata>
     this.groupVersionKind = groupVersionKind;
   }
 
+  @Override
   protected InformerEventSourceConfiguration.Builder<GenericKubernetesResource>
       informerConfigurationBuilder(EventSourceContext<P> context) {
     return InformerEventSourceConfiguration.from(


### PR DESCRIPTION
The curret implementation changed the underlying type, what is not we expect when passing an instance
will create issues when some compares GVKs that are first passed then read.
On the other hand if the user passes an instance of GVKP just can cast back.

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
