### PR TITLE
fix: a GVKP with no plural should be equivalent to the same GVK

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/GroupVersionKind.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/GroupVersionKind.java
@@ -101,9 +101,15 @@ public class GroupVersionKind {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    GroupVersionKind that = (GroupVersionKind) o;
-    return Objects.equals(apiVersion, that.apiVersion) && Objects.equals(kind, that.kind);
+    if (!(o instanceof GroupVersionKind that)) return false;
+    return Objects.equals(apiVersion, that.apiVersion)
+        && Objects.equals(kind, that.kind)
+        && specificEquals(that)
+        && that.specificEquals(this);
+  }
+
+  protected boolean specificEquals(GroupVersionKind that) {
+    return true;
   }
 
   @Override
@@ -113,13 +119,6 @@ public class GroupVersionKind {
 
   @Override
   public String toString() {
-    return "GroupVersionKind{"
-        + "apiVersion='"
-        + apiVersion
-        + '\''
-        + ", kind='"
-        + kind
-        + '\''
-        + '}';
+    return toGVKString();
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GroupVersionKindPlural.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GroupVersionKindPlural.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.processing.dependent.kubernetes;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.api.Pluralize;
@@ -33,6 +34,24 @@ public class GroupVersionKindPlural extends GroupVersionKind {
             : (gvk instanceof GroupVersionKindPlural
                 ? ((GroupVersionKindPlural) gvk).plural
                 : null));
+  }
+
+  @Override
+  protected boolean specificEquals(GroupVersionKind that) {
+    if (plural == null) {
+      return true;
+    }
+    return that instanceof GroupVersionKindPlural gvkp && gvkp.plural.equals(plural);
+  }
+
+  @Override
+  public int hashCode() {
+    return plural != null ? Objects.hash(super.hashCode(), plural) : super.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return toGVKString() + (plural != null ? " (plural: " + plural + ")" : "");
   }
 
   /**

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/GroupVersionKindTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/GroupVersionKindTest.java
@@ -61,19 +61,31 @@ class GroupVersionKindTest {
   @Test
   void pluralShouldBeEmptyIfNotProvided() {
     final var kind = "MyKind";
-    var gvk =
-        GroupVersionKindPlural.gvkWithPlural(new GroupVersionKind("josdk.io", "v1", kind), null);
+    final var original = new GroupVersionKind("josdk.io", "v1", kind);
+    var gvk = GroupVersionKindPlural.gvkWithPlural(original, null);
     assertThat(gvk.getPlural()).isEmpty();
     assertThat(gvk.getPluralOrDefault())
         .isEqualTo(GroupVersionKindPlural.getDefaultPluralFor(kind));
+    assertThat(gvk).isEqualTo(original);
+    assertThat(original).isEqualTo(gvk);
+    assertThat(gvk.hashCode()).isEqualTo(original.hashCode());
   }
 
   @Test
   void pluralShouldOverrideDefaultComputedVersionIfProvided() {
-    var gvk =
-        GroupVersionKindPlural.gvkWithPlural(
-            new GroupVersionKind("josdk.io", "v1", "MyKind"), "MyPlural");
+    final var original = new GroupVersionKind("josdk.io", "v1", "MyKind");
+    final var gvk = GroupVersionKindPlural.gvkWithPlural(original, "MyPlural");
     assertThat(gvk.getPlural()).hasValue("MyPlural");
+    assertThat(gvk).isNotEqualTo(original);
+    assertThat(original).isNotEqualTo(gvk);
+    assertThat(gvk.hashCode()).isNotEqualTo(original.hashCode());
+  }
+
+  @Test
+  void equals() {
+    final var original = new GroupVersionKind("josdk.io", "v1", "MyKind");
+    assertEquals(original, original);
+    assertFalse(original.equals(null));
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Chris Laprun <claprun@redhat.com>
