### PR TITLE
fix: use SSA matcher to filter events

### DIFF
--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcherTest.java
@@ -114,7 +114,25 @@ class SSABasedGenericKubernetesResourceMatcherTest {
 
     assertThat(matcher.matches(actualConfigMap, desiredConfigMap, mockedContext)).isFalse();
   }
+  
+  @Test
+  void compareActualSame() {
+    var actualConfigMap = loadResource("configmap.empty-owner-reference.yaml", ConfigMap.class);
 
+    assertThat(matcher.matches(actualConfigMap, actualConfigMap, mockedContext.getControllerConfiguration().fieldManager(), mockedContext.getClient(), true)).isTrue();
+  }
+  
+  @Test
+  void compareActualSameWithUnownedChange() {
+    var actualConfigMap = loadResource("configmap.empty-owner-reference.yaml", ConfigMap.class);
+    
+    var newConfigMap = loadResource("configmap.empty-owner-reference.yaml", ConfigMap.class);
+    newConfigMap.getMetadata().setLabels(Map.of("newlabel", "val"));
+
+    assertThat(matcher.matches(newConfigMap, actualConfigMap, mockedContext.getControllerConfiguration().fieldManager(), mockedContext.getClient(), true)).isTrue();
+    assertThat(matcher.matches(actualConfigMap, newConfigMap, mockedContext.getControllerConfiguration().fieldManager(), mockedContext.getClient(), true)).isTrue();
+  }
+  
   @Test
   @SuppressWarnings("unchecked")
   void sortListItemsTest() {


### PR DESCRIPTION
closes: #2249

Seeing the recent #2742, I was wondering about revisiting #2249. One thought shown roughly here is that if we use the SSA matcher to compare the new / old. If it matches, then the change may not be meaningful as it didn't touch an owned field. Any normalization that kubernetes does wouldn't cause false positives here.

It's currently wired in dubiously  - it probably would need to be done somehow via SSA enabled KubernetesDependentResources adding a filter to their informer event sources - which could make this independent of using the previous annotation.

When won't this work:
- if you need to react to changes in things you don't own
- if you miss handling an update that modifies your managed fields, after that point comparing the new / old like this doesn't help.

The only ways to workaround that I can think of would be to declare what non-owned state you care about and to track if we are behind on reconciling a resource - however these additional complexities may not be worth it.