### PR TITLE
fix: catch exceptions from updating the status

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
@@ -212,9 +212,18 @@ class ReconciliationDispatcher<P extends HasMetadata> {
 
     P updatedResource = null;
     if (errorStatusUpdateControl.getResource().isPresent()) {
-      updatedResource =
-          customResourceFacade.patchStatus(
-              errorStatusUpdateControl.getResource().orElseThrow(), originalResource);
+      try {
+        updatedResource =
+            customResourceFacade.patchStatus(
+                errorStatusUpdateControl.getResource().orElseThrow(), originalResource);
+      } catch (Exception ex) {
+        log.error(
+            "updateErrorStatus failed for resource: {} with version: {} for error {}",
+            getUID(resource),
+            getVersion(resource),
+            e.getMessage(),
+            ex);
+      }
     }
     if (errorStatusUpdateControl.isNoRetry()) {
       PostExecutionControl<P> postExecutionControl;


### PR DESCRIPTION
There are two possible handlings here:
- catch and log the error from the status patch, so that the original retry handling is preserved
- log the original exception, and let the error from the status patch take over as it does now

I opted for the former, but as open to the latter.

closes: #2751