### PR TITLE
Improve customizability of SSABasedGenericKubernetesResourceMacher

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -110,7 +110,7 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
 
     removeIrrelevantValues(desiredMap);
 
-    var matches = prunedActual.equals(desiredMap);
+    var matches = matches(prunedActual, desiredMap, actual, desired, context);
     if (!matches && log.isDebugEnabled() && LoggingUtils.isNotSensitiveResource(desired)) {
       var diff = getDiff(prunedActual, desiredMap, objectMapper);
       log.debug(
@@ -123,6 +123,28 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
           diff);
     }
     return matches;
+  }
+
+  /**
+   * Compares the desired and actual resources for equality.
+   *
+   * <p>This method can be overridden to implement custom matching logic. The {@code actualMap} is a
+   * cleaned-up version of the actual resource with managed fields and irrelevant values removed.
+   *
+   * @param actualMap the actual resource represented as a map
+   * @param desiredMap the desired resource represented as a map
+   * @param actual the actual resource object
+   * @param desired the desired resource object
+   * @param context the current matching context
+   * @return {@code true} if the resources are equal, otherwise {@code false}
+   */
+  protected boolean matches(
+      Map<String, Object> actualMap,
+      Map<String, Object> desiredMap,
+      R actual,
+      R desired,
+      Context<?> context) {
+    return actualMap.equals(desiredMap);
   }
 
   private String getDiff(


### PR DESCRIPTION
This PR addresses #2509 and makes it easier to customize the matching logic in SSABasedGenericKubernetesResourceMatcher without having to clone the entire class just to override its behavior.

The change is based on the solution suggested by @Donnerbart [here](https://github.com/operator-framework/java-operator-sdk/issues/2553#issuecomment-2493712071), but it avoids passing the primary resource directly in order to keep the existing matches method signature unchanged. If the primary resource is needed, it can instead be made available through the context.

The implementation introduces a new protected matches method that handles the actual comparison. The public matches method delegates to this new method, making it easy to override in subclasses.