### PR TITLE
[WIP] feat: support delete event reconiliation

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
@@ -92,4 +92,8 @@ public interface ControllerConfiguration<P extends HasMetadata> extends Informab
   }
 
   <C> C getConfigurationFor(DependentResourceSpec<?, P, C> spec);
+
+  default boolean reconcileOnPrimaryDelete() {
+    return false;
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
@@ -55,6 +55,8 @@ public interface Context<P extends HasMetadata> {
   @SuppressWarnings("unused")
   IndexedResourceCache<P> getPrimaryCache();
 
+  boolean isPrimaryDeleted();
+
   /**
    * Determines whether a new reconciliation will be triggered right after the current
    * reconciliation is finished. This allows to optimize certain situations, helping avoid unneeded

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ControllerConfiguration.java
@@ -77,4 +77,10 @@ public @interface ControllerConfiguration {
    * @return the name used as field manager for SSA operations
    */
   String fieldManager() default CONTROLLER_NAME_AS_FIELD_MANAGER;
+
+  /**
+   * Will trigger reconciliation on delete event of the primary resource. Can be set to true only if
+   * the reconciler does not implement {@link Cleaner} interface.
+   */
+  boolean reconcileOnPrimaryDelete() default false;
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
@@ -24,12 +24,15 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
   private final ControllerConfiguration<P> controllerConfiguration;
   private final DefaultManagedWorkflowAndDependentResourceContext<P>
       defaultManagedDependentResourceContext;
+  private final boolean isPrimaryDeleted;
 
-  public DefaultContext(RetryInfo retryInfo, Controller<P> controller, P primaryResource) {
+  public DefaultContext(
+      RetryInfo retryInfo, Controller<P> controller, P primaryResource, boolean isPrimaryDeleted) {
     this.retryInfo = retryInfo;
     this.controller = controller;
     this.primaryResource = primaryResource;
     this.controllerConfiguration = controller.getConfiguration();
+    this.isPrimaryDeleted = isPrimaryDeleted;
     this.defaultManagedDependentResourceContext =
         new DefaultManagedWorkflowAndDependentResourceContext<>(controller, primaryResource, this);
   }
@@ -47,6 +50,11 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
   @Override
   public IndexedResourceCache<P> getPrimaryCache() {
     return controller.getEventSourceManager().getControllerEventSource();
+  }
+
+  @Override
+  public boolean isPrimaryDeleted() {
+    return isPrimaryDeleted;
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ExecutionScope.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ExecutionScope.java
@@ -8,9 +8,11 @@ class ExecutionScope<R extends HasMetadata> {
   // the latest custom resource from cache
   private R resource;
   private final RetryInfo retryInfo;
+  private boolean isPrimaryDeleted = false;
 
-  ExecutionScope(RetryInfo retryInfo) {
+  ExecutionScope(RetryInfo retryInfo, boolean isPrimaryDeleted) {
     this.retryInfo = retryInfo;
+    this.isPrimaryDeleted = isPrimaryDeleted;
   }
 
   public ExecutionScope<R> setResource(R resource) {
@@ -41,5 +43,13 @@ class ExecutionScope<R extends HasMetadata> {
 
   public RetryInfo getRetryInfo() {
     return retryInfo;
+  }
+
+  public void setPrimaryDeleted(boolean primaryDeleted) {
+    isPrimaryDeleted = primaryDeleted;
+  }
+
+  public boolean isPrimaryDeleted() {
+    return isPrimaryDeleted;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
@@ -90,7 +90,11 @@ class ReconciliationDispatcher<P extends HasMetadata> {
     }
 
     Context<P> context =
-        new DefaultContext<>(executionScope.getRetryInfo(), controller, resourceForExecution);
+        new DefaultContext<>(
+            executionScope.getRetryInfo(),
+            controller,
+            resourceForExecution,
+            executionScope.isPrimaryDeleted());
     if (markedForDeletion) {
       return handleCleanup(resourceForExecution, originalResource, context);
     } else {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManager.java
@@ -5,17 +5,19 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-class ResourceStateManager {
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+class ResourceStateManager<P extends HasMetadata> {
   // maybe we should have a way for users to specify a hint on the amount of CRs their reconciler
   // will process to avoid under- or over-sizing the state maps and avoid too many resizing that
   // take time and memory?
-  private final Map<ResourceID, ResourceState> states = new ConcurrentHashMap<>(100);
+  private final Map<ResourceID, ResourceState<P>> states = new ConcurrentHashMap<>(100);
 
-  public ResourceState getOrCreate(ResourceID resourceID) {
+  public ResourceState<P> getOrCreate(ResourceID resourceID) {
     return states.computeIfAbsent(resourceID, ResourceState::new);
   }
 
-  public ResourceState remove(ResourceID resourceID) {
+  public ResourceState<P> remove(ResourceID resourceID) {
     return states.remove(resourceID);
   }
 
@@ -23,7 +25,7 @@ class ResourceStateManager {
     return states.containsKey(resourceID);
   }
 
-  public List<ResourceState> resourcesWithEventPresent() {
+  public List<ResourceState<P>> resourcesWithEventPresent() {
     return states.values().stream()
         .filter(state -> !state.noEventPresent())
         .collect(Collectors.toList());


### PR DESCRIPTION
The idea is that reconcile method will be called on resource delete event.
What would allow to clear inMemory caches without using a finalizer (thus Cleaner interface)

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
