### PR TITLE
allow to override test infrastructure kube client separately

### DIFF
--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/AbstractOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/AbstractOperatorExtension.java
@@ -38,6 +38,7 @@ public abstract class AbstractOperatorExtension
   public static final int DEFAULT_NAMESPACE_DELETE_TIMEOUT = 90;
 
   private final KubernetesClient kubernetesClient;
+  private final KubernetesClient infrastructureKubernetesClient;
   protected final List<HasMetadata> infrastructure;
   protected Duration infrastructureTimeout;
   protected final boolean oneNamespacePerClass;
@@ -56,10 +57,15 @@ public abstract class AbstractOperatorExtension
       boolean preserveNamespaceOnError,
       boolean waitForNamespaceDeletion,
       KubernetesClient kubernetesClient,
+      KubernetesClient infrastructureKubernetesClient,
       Function<ExtensionContext, String> namespaceNameSupplier,
       Function<ExtensionContext, String> perClassNamespaceNameSupplier) {
     this.kubernetesClient =
         kubernetesClient != null ? kubernetesClient : new KubernetesClientBuilder().build();
+    this.infrastructureKubernetesClient =
+        infrastructureKubernetesClient != null
+            ? infrastructureKubernetesClient
+            : new KubernetesClientBuilder().build();
     this.infrastructure = infrastructure;
     this.infrastructureTimeout = infrastructureTimeout;
     this.oneNamespacePerClass = oneNamespacePerClass;
@@ -92,6 +98,11 @@ public abstract class AbstractOperatorExtension
   @Override
   public KubernetesClient getKubernetesClient() {
     return kubernetesClient;
+  }
+
+  @Override
+  public KubernetesClient getInfrastructureKubernetesClient() {
+    return infrastructureKubernetesClient;
   }
 
   public String getNamespace() {
@@ -137,7 +148,7 @@ public abstract class AbstractOperatorExtension
   protected void before(ExtensionContext context) {
     LOGGER.info("Initializing integration test in namespace {}", namespace);
 
-    kubernetesClient
+    infrastructureKubernetesClient
         .namespaces()
         .resource(
             new NamespaceBuilder()
@@ -145,8 +156,8 @@ public abstract class AbstractOperatorExtension
                 .build())
         .serverSideApply();
 
-    kubernetesClient.resourceList(infrastructure).serverSideApply();
-    kubernetesClient
+    infrastructureKubernetesClient.resourceList(infrastructure).serverSideApply();
+    infrastructureKubernetesClient
         .resourceList(infrastructure)
         .waitUntilReady(infrastructureTimeout.toMillis(), TimeUnit.MILLISECONDS);
   }
@@ -168,16 +179,19 @@ public abstract class AbstractOperatorExtension
       if (preserveNamespaceOnError && context.getExecutionException().isPresent()) {
         LOGGER.info("Preserving namespace {}", namespace);
       } else {
-        kubernetesClient.resourceList(infrastructure).delete();
+        infrastructureKubernetesClient.resourceList(infrastructure).delete();
         deleteOperator();
         LOGGER.info("Deleting namespace {} and stopping operator", namespace);
-        kubernetesClient.namespaces().withName(namespace).delete();
+        infrastructureKubernetesClient.namespaces().withName(namespace).delete();
         if (waitForNamespaceDeletion) {
           LOGGER.info("Waiting for namespace {} to be deleted", namespace);
           Awaitility.await("namespace deleted")
               .pollInterval(50, TimeUnit.MILLISECONDS)
               .atMost(namespaceDeleteTimeout, TimeUnit.SECONDS)
-              .until(() -> kubernetesClient.namespaces().withName(namespace).get() == null);
+              .until(
+                  () ->
+                      infrastructureKubernetesClient.namespaces().withName(namespace).get()
+                          == null);
         }
       }
     }

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/ClusterDeployedOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/ClusterDeployedOperatorExtension.java
@@ -39,6 +39,7 @@ public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension 
       boolean waitForNamespaceDeletion,
       boolean oneNamespacePerClass,
       KubernetesClient kubernetesClient,
+      KubernetesClient infrastructureKubernetesClient,
       Function<ExtensionContext, String> namespaceNameSupplier,
       Function<ExtensionContext, String> perClassNamespaceNameSupplier) {
     super(
@@ -48,6 +49,7 @@ public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension 
         preserveNamespaceOnError,
         waitForNamespaceDeletion,
         kubernetesClient,
+        infrastructureKubernetesClient,
         namespaceNameSupplier,
         perClassNamespaceNameSupplier);
     this.operatorDeployment = operatorDeployment;
@@ -114,6 +116,7 @@ public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension 
     private final List<HasMetadata> operatorDeployment;
     private Duration deploymentTimeout;
     private KubernetesClient kubernetesClient;
+    private KubernetesClient infrastructureKubernetesClient;
 
     protected Builder() {
       super();
@@ -160,6 +163,9 @@ public class ClusterDeployedOperatorExtension extends AbstractOperatorExtension 
           waitForNamespaceDeletion,
           oneNamespacePerClass,
           kubernetesClient != null ? kubernetesClient : new KubernetesClientBuilder().build(),
+          infrastructureKubernetesClient != null
+              ? infrastructureKubernetesClient
+              : new KubernetesClientBuilder().build(),
           namespaceNameSupplier,
           perClassNamespaceNameSupplier);
     }

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/HasKubernetesClient.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/HasKubernetesClient.java
@@ -4,4 +4,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 
 public interface HasKubernetesClient {
   KubernetesClient getKubernetesClient();
+
+  KubernetesClient getInfrastructureKubernetesClient();
 }

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
@@ -65,6 +65,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
       boolean waitForNamespaceDeletion,
       boolean oneNamespacePerClass,
       KubernetesClient kubernetesClient,
+      KubernetesClient infrastructureKubernetesClient,
       Consumer<ConfigurationServiceOverrider> configurationServiceOverrider,
       Function<ExtensionContext, String> namespaceNameSupplier,
       Function<ExtensionContext, String> perClassNamespaceNameSupplier,
@@ -76,6 +77,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
         preserveNamespaceOnError,
         waitForNamespaceDeletion,
         kubernetesClient,
+        infrastructureKubernetesClient,
         namespaceNameSupplier,
         perClassNamespaceNameSupplier);
     this.reconcilers = reconcilers;
@@ -357,6 +359,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
     private final List<Class<? extends CustomResource>> additionalCustomResourceDefinitions;
     private final List<String> additionalCRDs = new ArrayList<>();
     private KubernetesClient kubernetesClient;
+    private KubernetesClient infrastructureKubernetesClient;
 
     protected Builder() {
       super();
@@ -411,6 +414,12 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
       return this;
     }
 
+    public Builder withInfrastructureKubernetesClient(
+        KubernetesClient infrastructureKubernetesClient) {
+      this.infrastructureKubernetesClient = infrastructureKubernetesClient;
+      return this;
+    }
+
     public Builder withAdditionalCustomResourceDefinition(
         Class<? extends CustomResource> customResource) {
       additionalCustomResourceDefinitions.add(customResource);
@@ -435,6 +444,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
           waitForNamespaceDeletion,
           oneNamespacePerClass,
           kubernetesClient,
+          infrastructureKubernetesClient,
           configurationServiceOverrider,
           namespaceNameSupplier,
           perClassNamespaceNameSupplier,


### PR DESCRIPTION
First part for #919. I believe it makes sense to split this into a separate PR. Let me know if I misunderstood where everywhere the infrastructure client should be used.