### PR TITLE
fix: minikube setup does not use github token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
     strategy:
       matrix:
         java: [ 17, 21, 24 ]
+        # Use the latest versions supported by minikube, otherwise GitHub it will
+        # end up in a throttling requests from minikube and workflow will fail.
+        # Minikube does such requests only if a version is not officially supported.
         kubernetes: [ '1.30.12', '1.31.8', '1.32.4','1.33.1' ]
     uses: ./.github/workflows/integration-tests.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17, 21, 24 ]
-        kubernetes: [ '1.30.12', '1.31.8', '1.32.4','1.33.0' ]
+        kubernetes: [ '1.30.12', '1.31.8', '1.32.4' ]
     uses: ./.github/workflows/integration-tests.yml
     with:
       java-version: ${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17, 21, 24 ]
-        kubernetes: [ '1.30.12', '1.31.8', '1.32.4' ]
+        kubernetes: [ '1.30.12', '1.31.8', '1.32.4','1.33.3' ]
     uses: ./.github/workflows/integration-tests.yml
     with:
       java-version: ${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17, 21, 24 ]
-        kubernetes: [ '1.30.12', '1.31.8', '1.32.4','1.33.3' ]
+        kubernetes: [ '1.30.12', '1.31.8', '1.32.4','1.33.1' ]
     uses: ./.github/workflows/integration-tests.yml
     with:
       java-version: ${{ matrix.java }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
           minikube version: v1.36.0
-          kubernetes version: v1.33.3
+          kubernetes version: v1.33.1
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,9 +34,9 @@ jobs:
         with:
           minikube version: v1.35.0
           kubernetes version: v1.33.0
-          github token: ${{ github.GITHUB_TOKEN }}
-          start args: '--force'
-          
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
       - name: Set up Java and Maven
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -35,7 +35,8 @@ jobs:
           minikube version: v1.35.0
           kubernetes version: v1.33.0
           github token: ${{ github.GITHUB_TOKEN }}
-
+          start args: '--force'
+          
       - name: Set up Java and Maven
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           minikube version: v1.34.0
           kubernetes version: v1.33.0
-          github token: ${{ secrets.GITHUB_TOKEN }}
+          github token: ${{ github.token }}
           driver: docker
 
       - name: Set up Java and Maven

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,6 +1,6 @@
 # Integration and end to end tests which runs locally and deploys the Operator to a Kubernetes
 # (Minikube) cluster and creates custom resources to verify the operator's functionality
-name: Integration & End to End tests
+name: End to End tests
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
           minikube version: v1.35.0
-          kubernetes version: v1.33.0
+          kubernetes version: v1.32.0
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -32,10 +32,9 @@ jobs:
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
-          minikube version: v1.34.0
+          minikube version: v1.35.0
           kubernetes version: v1.33.0
           github token: ${{ github.GITHUB_TOKEN }}
-          driver: docker
 
       - name: Set up Java and Maven
         uses: actions/setup-java@v4

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
-          minikube version: v1.35.0
-          kubernetes version: v1.32.0
+          minikube version: v1.36.0
+          kubernetes version: v1.33.3
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -33,6 +33,9 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
           minikube version: v1.36.0
+          # Use the latest versions supported by minikube, otherwise GitHub it will
+          # end up in a throttling requests from minikube and workflow will fail.
+          # Minikube does such requests only if a version is not officially supported.
           kubernetes version: v1.33.1
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           minikube version: v1.34.0
           kubernetes version: v1.33.0
-          github token: ${{ github.token }}
+          github token: ${{ github.GITHUB_TOKEN }}
           driver: docker
 
       - name: Set up Java and Maven

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Minikube
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
-          minikube version: 'v1.35.0'
+          minikube version: 'v1.36.0'
           kubernetes version: '${{ inputs.kube-version }}'
           github token: ${{ github.token }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
           minikube version: 'v1.34.0'
           kubernetes version: '${{ inputs.kube-version }}'
           driver: 'docker'
-          github token: ${{ secrets.GITHUB_TOKEN }}
+          github token: ${{ github.token }}
       - name: "${{inputs.it-category}} integration tests (kube: ${{ inputs.kube-version }} / java: ${{ inputs.java-version }} / client: ${{ inputs.http-client }})"
         run: |
           if [ -z "${{inputs.it-category}}" ]; then

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,6 +44,7 @@ jobs:
           minikube version: 'v1.35.0'
           kubernetes version: '${{ inputs.kube-version }}'
           github token: ${{ github.token }}
+          
       - name: "${{inputs.it-category}} integration tests (kube: ${{ inputs.kube-version }} / java: ${{ inputs.java-version }} / client: ${{ inputs.http-client }})"
         run: |
           if [ -z "${{inputs.it-category}}" ]; then

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
           minikube version: 'v1.35.0'
           kubernetes version: '${{ inputs.kube-version }}'
           github token: ${{ github.token }}
-          
+
       - name: "${{inputs.it-category}} integration tests (kube: ${{ inputs.kube-version }} / java: ${{ inputs.java-version }} / client: ${{ inputs.http-client }})"
         run: |
           if [ -z "${{inputs.it-category}}" ]; then

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,9 +41,8 @@ jobs:
       - name: Set up Minikube
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
-          minikube version: 'v1.34.0'
+          minikube version: 'v1.35.0'
           kubernetes version: '${{ inputs.kube-version }}'
-          driver: 'docker'
           github token: ${{ github.token }}
       - name: "${{inputs.it-category}} integration tests (kube: ${{ inputs.kube-version }} / java: ${{ inputs.java-version }} / client: ${{ inputs.http-client }})"
         run: |


### PR DESCRIPTION
Currently integration tests are being throttled, this should not happen when github token is used.
It seems that sub-workflows it should be passed or used as `github.token`, see here:
https://docs.github.com/en/actions/tutorials/use-github_token-in-workflows#using-the-github_token-in-a-workflow

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
