### PR TITLE
fix: Resolve race condition between visited flag and result of ready postcondition

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
@@ -144,9 +144,11 @@ class WorkflowReconcileExecutor<P extends HasMetadata> extends AbstractWorkflowE
       log.debug("Reconciling for primary: {} node: {} ", primaryID, dependentResourceNode);
       ReconcileResult reconcileResult = dependentResource.reconcile(primary, context);
       final var detailBuilder = createOrGetResultFor(dependentResourceNode);
-      detailBuilder.withReconcileResult(reconcileResult).markAsVisited();
 
-      if (isConditionMet(dependentResourceNode.getReadyPostcondition(), dependentResourceNode)) {
+      boolean isReadyPostconditionMet =
+          isConditionMet(dependentResourceNode.getReadyPostcondition(), dependentResourceNode);
+      detailBuilder.withReconcileResult(reconcileResult).markAsVisited();
+      if (isReadyPostconditionMet) {
         log.debug(
             "Setting already reconciled for: {} primaryID: {}", dependentResourceNode, primaryID);
         handleDependentsReconcile(dependentResourceNode);


### PR DESCRIPTION
Fix for a problem described in #2885. 

The changed code causes that when `visited` flag is changed to true, we are sure that readyPostconditionResult was checked before. In previous version, `visited` flag set to true and readyPostconditionResult equals null could describe two situations:
1. A resource was visited and its readyPostcondition is null.
2. A resource was visited and its readyPostcondition exists, but wasn't wasn't checked (race condition).

The changed code doesn't let the second situation to happen.