### PR TITLE
fix: create state only on resource event

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -102,8 +102,16 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
     try {
       log.debug("Received event: {}", event);
 
+      final var optionalState = resourceStateManager.getOrCreateOnResourceEvent(event);
+      if (optionalState.isEmpty()) {
+        log.debug(
+            "Skipping event, since no state present and it is not a resource event. Resource ID:"
+                + " {}",
+            event.getRelatedCustomResourceID());
+        return;
+      }
+      var state = optionalState.orElseThrow();
       final var resourceID = event.getRelatedCustomResourceID();
-      final var state = resourceStateManager.getOrCreate(event.getRelatedCustomResourceID());
       MDCUtils.addResourceIDInfo(resourceID);
       metrics.receivedEvent(event, metricsMetadata);
       handleEventMarking(event, state);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManager.java
@@ -2,14 +2,32 @@ package io.javaoperatorsdk.operator.processing.event;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEvent;
 
 class ResourceStateManager {
   // maybe we should have a way for users to specify a hint on the amount of CRs their reconciler
   // will process to avoid under- or over-sizing the state maps and avoid too many resizing that
   // take time and memory?
   private final Map<ResourceID, ResourceState> states = new ConcurrentHashMap<>(100);
+
+  public Optional<ResourceState> getOrCreateOnResourceEvent(Event event) {
+    var resourceId = event.getRelatedCustomResourceID();
+    var state = states.get(event.getRelatedCustomResourceID());
+    if (state != null) {
+      return Optional.of(state);
+    }
+    if (event instanceof ResourceEvent) {
+      state = new ResourceState(resourceId);
+      states.put(resourceId, state);
+      return Optional.of(state);
+    } else {
+      return Optional.empty();
+    }
+  }
 
   public ResourceState getOrCreate(ResourceID resourceID) {
     return states.computeIfAbsent(resourceID, ResourceState::new);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManagerTest.java
@@ -4,6 +4,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.javaoperatorsdk.operator.TestUtils;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceAction;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEvent;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ResourceStateManagerTest {
@@ -86,5 +90,27 @@ class ResourceStateManagerTest {
 
     assertThat(res).hasSize(1);
     assertThat(res.get(0).getId()).isEqualTo(sampleResourceID2);
+  }
+
+  @Test
+  void createStateOnlyOnResourceEvent() {
+    var state = manager.getOrCreateOnResourceEvent(new Event(new ResourceID("newEvent")));
+
+    assertThat(state).isEmpty();
+
+    state =
+        manager.getOrCreateOnResourceEvent(
+            new ResourceEvent(
+                ResourceAction.ADDED, new ResourceID("newEvent"), TestUtils.testCustomResource()));
+
+    assertThat(state).isNotNull();
+  }
+
+  @Test
+  void createsOnlyResourceEventReturnsPreviouslyCreatedState() {
+    manager.getOrCreate(new ResourceID("newEvent"));
+
+    var res = manager.getOrCreateOnResourceEvent(new Event(new ResourceID("newEvent")));
+    assertThat(res).isNotNull();
   }
 }


### PR DESCRIPTION
In general we cleanup state on delete event, so although in practice this probably not causing
issues in theory it can happen that we receive events where there is no related custom resource.
What effectivel means a memory leak, since that state never cleaned up - again it is more theoretical than practical issues, since it practice usually events are propagated related to a custom resource (or based on that).

This PR fixes it in a way that it checks that when state is created it is alway related to a resource event (thus for primary / custom resource). In that way avoiding that state is created without a primary resource. 

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
