### PR TITLE
improve: Make MicrometerMetrics extendable

### DIFF
--- a/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/AbstractMicrometerMetricsTestFixture.java
+++ b/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/AbstractMicrometerMetricsTestFixture.java
@@ -87,7 +87,7 @@ public abstract class AbstractMicrometerMetricsTestFixture {
     }
   }
 
-  static class TestSimpleMeterRegistry extends SimpleMeterRegistry {
+  protected static class TestSimpleMeterRegistry extends SimpleMeterRegistry {
     private final Set<Meter.Id> removed = new HashSet<>();
 
     @Override

--- a/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/CleanerBuilderTest.java
+++ b/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/CleanerBuilderTest.java
@@ -1,0 +1,73 @@
+package io.javaoperatorsdk.operator.monitoring.micrometer;
+
+import org.junit.jupiter.api.Test;
+
+import io.javaoperatorsdk.operator.monitoring.micrometer.MicrometerMetrics.CleanerBuilder;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CleanerBuilderTest {
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+  @Test
+  void test_defaultsToNoopCleaner() {
+    final var cleaner = new CleanerBuilder(registry).build();
+    assertThat(cleaner).isSameAs(MicrometerMetrics.Cleaner.NOOP);
+  }
+
+  @Test
+  void test_withCleaningThreadNumber() {
+    final var cleaner = new CleanerBuilder(registry).withCleaningThreadNumber(42).build();
+    assertThat(cleaner).isInstanceOf(MicrometerMetrics.DelayedCleaner.class);
+    if (cleaner instanceof MicrometerMetrics.DelayedCleaner delayedCleaner) {
+      assertThat(delayedCleaner.getCleanUpDelayInSeconds()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  void test_withCleaningThreadNumber_whenNegative_thenApplyDefault() {
+    final var cleaner = new CleanerBuilder(registry).withCleaningThreadNumber(42).build();
+    assertThat(cleaner).isInstanceOf(MicrometerMetrics.DelayedCleaner.class);
+    if (cleaner instanceof MicrometerMetrics.DelayedCleaner delayedCleaner) {
+      assertThat(delayedCleaner.getCleanUpDelayInSeconds()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  void test_withCleaningThreadNumber_whenZero_thenApplyDefault() {
+    final var cleaner = new CleanerBuilder(registry).withCleaningThreadNumber(0).build();
+    assertThat(cleaner).isInstanceOf(MicrometerMetrics.DelayedCleaner.class);
+    if (cleaner instanceof MicrometerMetrics.DelayedCleaner delayedCleaner) {
+      assertThat(delayedCleaner.getCleanUpDelayInSeconds()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  void test_withCleanUpDelayInSeconds() {
+    final var cleaner = new CleanerBuilder(registry).withCleanUpDelayInSeconds(23).build();
+    assertThat(cleaner).isInstanceOf(MicrometerMetrics.DelayedCleaner.class);
+    if (cleaner instanceof MicrometerMetrics.DelayedCleaner delayedCleaner) {
+      assertThat(delayedCleaner.getCleanUpDelayInSeconds()).isEqualTo(23);
+    }
+  }
+
+  @Test
+  void test_withCleanUpDelayInSeconds_whenNegative_thenApplyDefault() {
+    final var cleaner = new CleanerBuilder(registry).withCleanUpDelayInSeconds(-23).build();
+    assertThat(cleaner).isInstanceOf(MicrometerMetrics.DelayedCleaner.class);
+    if (cleaner instanceof MicrometerMetrics.DelayedCleaner delayedCleaner) {
+      assertThat(delayedCleaner.getCleanUpDelayInSeconds()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void test_withCleanUpDelayInSeconds_whenZero_thenApplyDefault() {
+    final var cleaner = new CleanerBuilder(registry).withCleanUpDelayInSeconds(0).build();
+    assertThat(cleaner).isInstanceOf(MicrometerMetrics.DelayedCleaner.class);
+    if (cleaner instanceof MicrometerMetrics.DelayedCleaner delayedCleaner) {
+      assertThat(delayedCleaner.getCleanUpDelayInSeconds()).isEqualTo(1);
+    }
+  }
+}

--- a/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/DefaultBehaviorIT.java
+++ b/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/DefaultBehaviorIT.java
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.Meter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultBehaviorIT extends AbstractMicrometerMetricsTestFixture {
+
   @Override
   protected MicrometerMetrics getMetrics() {
     return MicrometerMetrics.newMicrometerMetricsBuilder(registry).build();

--- a/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/DefaultBehaviorWithCustomImplementationIT.java
+++ b/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/DefaultBehaviorWithCustomImplementationIT.java
@@ -1,0 +1,18 @@
+package io.javaoperatorsdk.operator.monitoring.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class DefaultBehaviorWithCustomImplementationIT extends DefaultBehaviorIT {
+
+  @Override
+  protected MicrometerMetrics getMetrics() {
+    return new TestMetrics(registry);
+  }
+
+  private static class TestMetrics extends MicrometerMetrics {
+
+    private TestMetrics(MeterRegistry registry) {
+      super(registry, new CleanerBuilder(registry).build(), true);
+    }
+  }
+}

--- a/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/DelayedMetricsCleaningOnDeleteIT.java
+++ b/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/DelayedMetricsCleaningOnDeleteIT.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DelayedMetricsCleaningOnDeleteIT extends AbstractMicrometerMetricsTestFixture {
 
-  private static final int testDelay = 1;
+  protected static final int testDelay = 1;
 
   @Override
   protected MicrometerMetrics getMetrics() {

--- a/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/DelayedMetricsCleaningOnDeleteWithCustomImplementationIT.java
+++ b/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/DelayedMetricsCleaningOnDeleteWithCustomImplementationIT.java
@@ -1,0 +1,25 @@
+package io.javaoperatorsdk.operator.monitoring.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class DelayedMetricsCleaningOnDeleteWithCustomImplementationIT
+    extends DelayedMetricsCleaningOnDeleteIT {
+
+  @Override
+  protected MicrometerMetrics getMetrics() {
+    return new TestMetrics(registry);
+  }
+
+  private static class TestMetrics extends MicrometerMetrics {
+
+    private TestMetrics(MeterRegistry registry) {
+      super(
+          registry,
+          new CleanerBuilder(registry)
+              .withCleanUpDelayInSeconds(testDelay)
+              .withCleaningThreadNumber(2)
+              .build(),
+          true);
+    }
+  }
+}

--- a/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/NoPerResourceCollectionIT.java
+++ b/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/NoPerResourceCollectionIT.java
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.Meter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class NoPerResourceCollectionIT extends AbstractMicrometerMetricsTestFixture {
+
   @Override
   protected MicrometerMetrics getMetrics() {
     return MicrometerMetrics.withoutPerResourceMetrics(registry);

--- a/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/NoPerResourceCollectionWithCustomImplementationIT.java
+++ b/micrometer-support/src/test/java/io/javaoperatorsdk/operator/monitoring/micrometer/NoPerResourceCollectionWithCustomImplementationIT.java
@@ -1,0 +1,18 @@
+package io.javaoperatorsdk.operator.monitoring.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class NoPerResourceCollectionWithCustomImplementationIT extends NoPerResourceCollectionIT {
+
+  @Override
+  protected MicrometerMetrics getMetrics() {
+    return new TestMetrics(registry);
+  }
+
+  private static class TestMetrics extends MicrometerMetrics {
+
+    private TestMetrics(MeterRegistry registry) {
+      super(registry, new CleanerBuilder(registry).build(), false);
+    }
+  }
+}


### PR DESCRIPTION
Partially fixes #2884

As mentioned in the issue:
> I think implementing a custom metrics interface, or extending the current implementation with micrometer, should do the job

The latter is not possible due to the private constructor and private Cleaner implementations. This is an attempt to make the `MicrometerMetrics` class extendable without exposing all `Cleaner` implementations.