### PR TITLE
improve: GenericRetry does not provide mutable singleton instance

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
@@ -57,7 +57,7 @@ public interface ControllerConfiguration<P extends HasMetadata> extends Informab
   String getAssociatedReconcilerClassName();
 
   default Retry getRetry() {
-    return GenericRetry.DEFAULT;
+    return GenericRetry.defaultLimitedExponentialRetry();
   }
 
   @SuppressWarnings("rawtypes")

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/GenericRetry.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/GenericRetry.java
@@ -10,10 +10,15 @@ public class GenericRetry implements Retry, AnnotationConfigurable<GradualRetry>
   private double intervalMultiplier = GradualRetry.DEFAULT_MULTIPLIER;
   private long maxInterval = GradualRetry.DEFAULT_MAX_INTERVAL;
 
+  /**
+   * @deprecated use {@link GenericRetry#defaultLimitedExponentialRetry()} instead this instance.
+   *     Since GenericRetry is mutable, singleton is problematic.
+   */
+  @Deprecated(forRemoval = true)
   public static final Retry DEFAULT = new GenericRetry();
 
   public static GenericRetry defaultLimitedExponentialRetry() {
-    return (GenericRetry) DEFAULT;
+    return new GenericRetry();
   }
 
   public static GenericRetry noRetry() {


### PR DESCRIPTION
This might easily result in unintended side effect if someone uses `DEFAULT` instance in one controller, changes some paramter; then uses the instance for an other controller, in that case the changed parameter will apply also for other controller what is quite unintuitive