### PR TITLE
 [WIP] feat: experimental utility methods to add finalizer

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/ReconcilerUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/ReconcilerUtils.java
@@ -6,14 +6,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import io.fabric8.kubernetes.api.builder.Builder;
-import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -71,36 +68,6 @@ public class ReconcilerUtils {
     }
     // otherwise, use the lower-cased full class name
     return getDefaultNameFor(reconcilerClass);
-  }
-
-  public static void checkIfCanAddOwnerReference(HasMetadata owner, HasMetadata resource) {
-    if (owner instanceof GenericKubernetesResource
-        || resource instanceof GenericKubernetesResource) {
-      return;
-    }
-    if (owner instanceof Namespaced) {
-      if (!(resource instanceof Namespaced)) {
-        throw new OperatorException(
-            "Cannot add owner reference from a cluster scoped to a namespace scoped resource."
-                + resourcesIdentifierDescription(owner, resource));
-      } else if (!Objects.equals(
-          owner.getMetadata().getNamespace(), resource.getMetadata().getNamespace())) {
-        throw new OperatorException(
-            "Cannot add owner reference between two resource in different namespaces."
-                + resourcesIdentifierDescription(owner, resource));
-      }
-    }
-  }
-
-  private static String resourcesIdentifierDescription(HasMetadata owner, HasMetadata resource) {
-    return " Owner name: "
-        + owner.getMetadata().getName()
-        + " Kind: "
-        + owner.getKind()
-        + ", Resource name: "
-        + resource.getMetadata().getName()
-        + " Kind: "
-        + resource.getKind();
   }
 
   public static String getNameFor(Reconciler reconciler) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ControllerConfiguration.java
@@ -57,7 +57,7 @@ public interface ControllerConfiguration<P extends HasMetadata> extends Informab
   String getAssociatedReconcilerClassName();
 
   default Retry getRetry() {
-    return GenericRetry.DEFAULT;
+    return GenericRetry.defaultLimitedExponentialRetry();
   }
 
   @SuppressWarnings("rawtypes")

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/Field.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/Field.java
@@ -1,0 +1,10 @@
+package io.javaoperatorsdk.operator.api.config.informer;
+
+public @interface Field {
+
+  String path();
+
+  String value();
+
+  boolean negated() default false;
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/FieldSelector.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/FieldSelector.java
@@ -1,0 +1,26 @@
+package io.javaoperatorsdk.operator.api.config.informer;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FieldSelector {
+  private final List<Field> fields;
+
+  public FieldSelector(List<Field> fields) {
+    this.fields = fields;
+  }
+
+  public FieldSelector(Field... fields) {
+    this.fields = Arrays.asList(fields);
+  }
+
+  public List<Field> getFields() {
+    return fields;
+  }
+
+  public record Field(String path, String value, boolean negated) {
+    public Field(String path, String value) {
+      this(path, value, false);
+    }
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/FieldSelectorBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/FieldSelectorBuilder.java
@@ -1,0 +1,23 @@
+package io.javaoperatorsdk.operator.api.config.informer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FieldSelectorBuilder {
+
+  private final List<FieldSelector.Field> fields = new ArrayList<>();
+
+  public FieldSelectorBuilder withField(String path, String value) {
+    fields.add(new FieldSelector.Field(path, value));
+    return this;
+  }
+
+  public FieldSelectorBuilder withoutField(String path, String value) {
+    fields.add(new FieldSelector.Field(path, value, true));
+    return this;
+  }
+
+  public FieldSelector build() {
+    return new FieldSelector(fields);
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/Informer.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/Informer.java
@@ -113,4 +113,7 @@ public @interface Informer {
    * the informer cache.
    */
   long informerListLimit() default NO_LONG_VALUE_SET;
+
+  /** Kubernetes field selector for additional resource filtering */
+  Field[] fieldSelector() default {};
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerConfiguration.java
@@ -1,5 +1,6 @@
 package io.javaoperatorsdk.operator.api.config.informer;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -36,6 +37,7 @@ public class InformerConfiguration<R extends HasMetadata> {
   private GenericFilter<? super R> genericFilter;
   private ItemStore<R> itemStore;
   private Long informerListLimit;
+  private FieldSelector fieldSelector;
 
   protected InformerConfiguration(
       Class<R> resourceClass,
@@ -48,7 +50,8 @@ public class InformerConfiguration<R extends HasMetadata> {
       OnDeleteFilter<? super R> onDeleteFilter,
       GenericFilter<? super R> genericFilter,
       ItemStore<R> itemStore,
-      Long informerListLimit) {
+      Long informerListLimit,
+      FieldSelector fieldSelector) {
     this(resourceClass);
     this.name = name;
     this.namespaces = namespaces;
@@ -60,6 +63,7 @@ public class InformerConfiguration<R extends HasMetadata> {
     this.genericFilter = genericFilter;
     this.itemStore = itemStore;
     this.informerListLimit = informerListLimit;
+    this.fieldSelector = fieldSelector;
   }
 
   private InformerConfiguration(Class<R> resourceClass) {
@@ -93,7 +97,8 @@ public class InformerConfiguration<R extends HasMetadata> {
             original.onDeleteFilter,
             original.genericFilter,
             original.itemStore,
-            original.informerListLimit)
+            original.informerListLimit,
+            original.fieldSelector)
         .builder;
   }
 
@@ -264,6 +269,10 @@ public class InformerConfiguration<R extends HasMetadata> {
     return informerListLimit;
   }
 
+  public FieldSelector getFieldSelector() {
+    return fieldSelector;
+  }
+
   @SuppressWarnings("UnusedReturnValue")
   public class Builder {
 
@@ -329,6 +338,12 @@ public class InformerConfiguration<R extends HasMetadata> {
         final var informerListLimit =
             informerListLimitValue == Constants.NO_LONG_VALUE_SET ? null : informerListLimitValue;
         withInformerListLimit(informerListLimit);
+
+        withFieldSelector(
+            new FieldSelector(
+                Arrays.stream(informerConfig.fieldSelector())
+                    .map(f -> new FieldSelector.Field(f.path(), f.value(), f.negated()))
+                    .toList()));
       }
       return this;
     }
@@ -422,6 +437,11 @@ public class InformerConfiguration<R extends HasMetadata> {
 
     public Builder withInformerListLimit(Long informerListLimit) {
       InformerConfiguration.this.informerListLimit = informerListLimit;
+      return this;
+    }
+
+    public Builder withFieldSelector(FieldSelector fieldSelector) {
+      InformerConfiguration.this.fieldSelector = fieldSelector;
       return this;
     }
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
@@ -265,6 +265,11 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
       return this;
     }
 
+    public Builder<R> withFieldSelector(FieldSelector fieldSelector) {
+      config.withFieldSelector(fieldSelector);
+      return this;
+    }
+
     public void updateFrom(InformerConfiguration<R> informerConfig) {
       if (informerConfig != null) {
         final var informerConfigName = informerConfig.getName();
@@ -281,7 +286,8 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
             .withOnUpdateFilter(informerConfig.getOnUpdateFilter())
             .withOnDeleteFilter(informerConfig.getOnDeleteFilter())
             .withGenericFilter(informerConfig.getGenericFilter())
-            .withInformerListLimit(informerConfig.getInformerListLimit());
+            .withInformerListLimit(informerConfig.getInformerListLimit())
+            .withFieldSelector(informerConfig.getFieldSelector());
       }
     }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/monitoring/AggregatedMetrics.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/monitoring/AggregatedMetrics.java
@@ -1,0 +1,105 @@
+package io.javaoperatorsdk.operator.api.monitoring;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
+import io.javaoperatorsdk.operator.processing.Controller;
+import io.javaoperatorsdk.operator.processing.event.Event;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+
+/**
+ * An aggregated implementation of the {@link Metrics} interface that delegates method calls to a
+ * collection of {@link Metrics} instances using the composite pattern.
+ *
+ * <p>This class allows multiple metrics providers to be combined into a single metrics instance,
+ * enabling simultaneous collection of metrics data by different monitoring systems or providers.
+ * All method calls are delegated to each metrics instance in the list in the order they were
+ * provided to the constructor.
+ *
+ * <p><strong>Important:</strong> The {@link #timeControllerExecution(ControllerExecution)} method
+ * is handled specially - it is only invoked on the first metrics instance in the list, since it's
+ * not an idempotent operation and can only be executed once. The controller execution cannot be
+ * repeated multiple times as it would produce side effects and potentially inconsistent results.
+ *
+ * <p>All other methods are called on every metrics instance in the list, preserving the order of
+ * execution as specified in the constructor.
+ *
+ * @see Metrics
+ */
+public final class AggregatedMetrics implements Metrics {
+
+  private final List<Metrics> metricsList;
+
+  /**
+   * Creates a new AggregatedMetrics instance that will delegate method calls to the provided list
+   * of metrics instances.
+   *
+   * @param metricsList the list of metrics instances to delegate to; must not be null and must
+   *     contain at least one metrics instance
+   * @throws NullPointerException if metricsList is null
+   * @throws IllegalArgumentException if metricsList is empty
+   */
+  public AggregatedMetrics(List<Metrics> metricsList) {
+    Objects.requireNonNull(metricsList, "metricsList must not be null");
+    if (metricsList.isEmpty()) {
+      throw new IllegalArgumentException("metricsList must contain at least one Metrics instance");
+    }
+    this.metricsList = List.copyOf(metricsList);
+  }
+
+  @Override
+  public void controllerRegistered(Controller<? extends HasMetadata> controller) {
+    metricsList.forEach(metrics -> metrics.controllerRegistered(controller));
+  }
+
+  @Override
+  public void receivedEvent(Event event, Map<String, Object> metadata) {
+    metricsList.forEach(metrics -> metrics.receivedEvent(event, metadata));
+  }
+
+  @Override
+  public void reconcileCustomResource(
+      HasMetadata resource, RetryInfo retryInfo, Map<String, Object> metadata) {
+    metricsList.forEach(metrics -> metrics.reconcileCustomResource(resource, retryInfo, metadata));
+  }
+
+  @Override
+  public void failedReconciliation(
+      HasMetadata resource, Exception exception, Map<String, Object> metadata) {
+    metricsList.forEach(metrics -> metrics.failedReconciliation(resource, exception, metadata));
+  }
+
+  @Override
+  public void reconciliationExecutionStarted(HasMetadata resource, Map<String, Object> metadata) {
+    metricsList.forEach(metrics -> metrics.reconciliationExecutionStarted(resource, metadata));
+  }
+
+  @Override
+  public void reconciliationExecutionFinished(HasMetadata resource, Map<String, Object> metadata) {
+    metricsList.forEach(metrics -> metrics.reconciliationExecutionFinished(resource, metadata));
+  }
+
+  @Override
+  public void cleanupDoneFor(ResourceID resourceID, Map<String, Object> metadata) {
+    metricsList.forEach(metrics -> metrics.cleanupDoneFor(resourceID, metadata));
+  }
+
+  @Override
+  public void finishedReconciliation(HasMetadata resource, Map<String, Object> metadata) {
+    metricsList.forEach(metrics -> metrics.finishedReconciliation(resource, metadata));
+  }
+
+  @Override
+  public <T> T timeControllerExecution(ControllerExecution<T> execution) throws Exception {
+    return metricsList.get(0).timeControllerExecution(execution);
+  }
+
+  @Override
+  public <T extends Map<?, ?>> T monitorSizeOf(T map, String name) {
+    metricsList.forEach(metrics -> metrics.monitorSizeOf(map, name));
+    return map;
+  }
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Experimental.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Experimental.java
@@ -1,0 +1,24 @@
+package io.javaoperatorsdk.operator.api.reconciler;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks experimental features.
+ *
+ * <p>Experimental features are not yet stable and may change in future releases. Usually based on
+ * the feedback of the users.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD, ElementType.PACKAGE})
+public @interface Experimental {
+
+  /**
+   * Describes why the annotated element is experimental.
+   *
+   * @return the experimental description.
+   */
+  String value();
+}

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
@@ -235,10 +235,10 @@ public class PrimaryUpdateAndCacheUtils {
    * therefore makes less Kubernetes API Calls.
    */
   @Experimental(
-          "Not used internally for now. Therefor we don't consider it well tested. But the intention is"
-                  + " to have it as default in the future.")
+      "Not used internally for now. Therefor we don't consider it well tested. But the intention is"
+          + " to have it as default in the future.")
   public static <P extends HasMetadata> P addFinalizer(
-          P resource, String finalizer, Context<P> context) {
+      P resource, String finalizer, Context<P> context) {
 
     if (resource.hasFinalizer(finalizer)) {
       log.debug("Skipping adding finalizer, since already present.");
@@ -246,18 +246,18 @@ public class PrimaryUpdateAndCacheUtils {
     }
 
     return updateAndCacheResource(
-            resource,
-            context,
-            r -> r,
-            r ->
-                    context
-                            .getClient()
-                            .resource(r)
-                            .edit(
-                                    res -> {
-                                      res.addFinalizer(finalizer);
-                                      return res;
-                                    }));
+        resource,
+        context,
+        r -> r,
+        r ->
+            context
+                .getClient()
+                .resource(r)
+                .edit(
+                    res -> {
+                      res.addFinalizer(finalizer);
+                      return res;
+                    }));
   }
 
   /**
@@ -265,26 +265,26 @@ public class PrimaryUpdateAndCacheUtils {
    * therefore makes less Kubernetes API Calls.
    */
   @Experimental(
-          "Not used internally for now. Therefor we don't consider it well tested. But the intention is"
-                  + " to have it as default in the future.")
+      "Not used internally for now. Therefor we don't consider it well tested. But the intention is"
+          + " to have it as default in the future.")
   public static <P extends HasMetadata> P removeFinalizer(
-          P resource, String finalizer, Context<P> context) {
+      P resource, String finalizer, Context<P> context) {
     if (!resource.hasFinalizer(finalizer)) {
       log.debug("Skipping removing finalizer, since not present.");
       return resource;
     }
     return updateAndCacheResource(
-            resource,
-            context,
-            r -> r,
-            r ->
-                    context
-                            .getClient()
-                            .resource(r)
-                            .edit(
-                                    res -> {
-                                      res.removeFinalizer(finalizer);
-                                      return res;
-                                    }));
+        resource,
+        context,
+        r -> r,
+        r ->
+            context
+                .getClient()
+                .resource(r)
+                .edit(
+                    res -> {
+                      res.removeFinalizer(finalizer);
+                      return res;
+                    }));
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
@@ -229,4 +229,62 @@ public class PrimaryUpdateAndCacheUtils {
       throw new OperatorException(e);
     }
   }
+
+  /**
+   * Experimental. Patches finalizer. For retry uses informer cache to get the fresh resources,
+   * therefore makes less Kubernetes API Calls.
+   */
+  @Experimental(
+          "Not used internally for now. Therefor we don't consider it well tested. But the intention is"
+                  + " to have it as default in the future.")
+  public static <P extends HasMetadata> P addFinalizer(
+          P resource, String finalizer, Context<P> context) {
+
+    if (resource.hasFinalizer(finalizer)) {
+      log.debug("Skipping adding finalizer, since already present.");
+      return resource;
+    }
+
+    return updateAndCacheResource(
+            resource,
+            context,
+            r -> r,
+            r ->
+                    context
+                            .getClient()
+                            .resource(r)
+                            .edit(
+                                    res -> {
+                                      res.addFinalizer(finalizer);
+                                      return res;
+                                    }));
+  }
+
+  /**
+   * Experimental. Removes finalizer, for retry uses informer cache to get the fresh resources,
+   * therefore makes less Kubernetes API Calls.
+   */
+  @Experimental(
+          "Not used internally for now. Therefor we don't consider it well tested. But the intention is"
+                  + " to have it as default in the future.")
+  public static <P extends HasMetadata> P removeFinalizer(
+          P resource, String finalizer, Context<P> context) {
+    if (!resource.hasFinalizer(finalizer)) {
+      log.debug("Skipping removing finalizer, since not present.");
+      return resource;
+    }
+    return updateAndCacheResource(
+            resource,
+            context,
+            r -> r,
+            r ->
+                    context
+                            .getClient()
+                            .resource(r)
+                            .edit(
+                                    res -> {
+                                      res.removeFinalizer(finalizer);
+                                      return res;
+                                    }));
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.config.dependent.Configured;
 import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -208,7 +207,6 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
 
   protected void addReferenceHandlingMetadata(R desired, P primary) {
     if (addOwnerReference()) {
-      ReconcilerUtils.checkIfCanAddOwnerReference(primary, desired);
       desired.addOwnerReference(primary);
     } else if (useNonOwnerRefBasedSecondaryToPrimaryMapping()) {
       addSecondaryToPrimaryMapperAnnotations(desired, primary);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
@@ -134,6 +134,18 @@ class InformerManager<R extends HasMetadata, C extends Informable<R>>
       ResourceEventHandler<R> eventHandler,
       String namespaceIdentifier) {
     final var informerConfig = configuration.getInformerConfig();
+
+    if (informerConfig.getFieldSelector() != null
+        && !informerConfig.getFieldSelector().getFields().isEmpty()) {
+      for (var f : informerConfig.getFieldSelector().getFields()) {
+        if (f.negated()) {
+          filteredBySelectorClient = filteredBySelectorClient.withoutField(f.path(), f.value());
+        } else {
+          filteredBySelectorClient = filteredBySelectorClient.withField(f.path(), f.value());
+        }
+      }
+    }
+
     var informer =
         Optional.ofNullable(informerConfig.getInformerListLimit())
             .map(filteredBySelectorClient::withLimit)

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/GenericRetry.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/GenericRetry.java
@@ -1,5 +1,7 @@
 package io.javaoperatorsdk.operator.processing.retry;
 
+import java.time.Duration;
+
 import io.javaoperatorsdk.operator.api.config.AnnotationConfigurable;
 
 public class GenericRetry implements Retry, AnnotationConfigurable<GradualRetry> {
@@ -38,6 +40,11 @@ public class GenericRetry implements Retry, AnnotationConfigurable<GradualRetry>
 
   public long getInitialInterval() {
     return initialInterval;
+  }
+
+  public GenericRetry setInitialInterval(Duration initialInterval) {
+    setInitialInterval(initialInterval.toMillis());
+    return this;
   }
 
   public GenericRetry setInitialInterval(long initialInterval) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/GenericRetry.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/GenericRetry.java
@@ -10,10 +10,15 @@ public class GenericRetry implements Retry, AnnotationConfigurable<GradualRetry>
   private double intervalMultiplier = GradualRetry.DEFAULT_MULTIPLIER;
   private long maxInterval = GradualRetry.DEFAULT_MAX_INTERVAL;
 
+  /**
+   * @deprecated use {@link GenericRetry#defaultLimitedExponentialRetry()} instead this instance.
+   *     Since GenericRetry is mutable, singleton is problematic.
+   */
+  @Deprecated(forRemoval = true)
   public static final Retry DEFAULT = new GenericRetry();
 
   public static GenericRetry defaultLimitedExponentialRetry() {
-    return (GenericRetry) DEFAULT;
+    return new GenericRetry();
   }
 
   public static GenericRetry noRetry() {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/ReconcilerUtilsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/ReconcilerUtilsTest.java
@@ -8,8 +8,6 @@ import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
-import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
-import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.http.HttpRequest;
@@ -152,44 +150,6 @@ class ReconcilerUtilsTest {
                     null,
                     request),
                 HasMetadata.getFullResourceName(Tomcat.class)));
-  }
-
-  @Test
-  void checksIfOwnerReferenceCanBeAdded() {
-    assertThrows(
-        OperatorException.class,
-        () ->
-            ReconcilerUtils.checkIfCanAddOwnerReference(
-                namespacedResource(), namespacedResourceFromOtherNamespace()));
-
-    assertThrows(
-        OperatorException.class,
-        () ->
-            ReconcilerUtils.checkIfCanAddOwnerReference(
-                namespacedResource(), clusterScopedResource()));
-
-    assertDoesNotThrow(
-        () -> {
-          ReconcilerUtils.checkIfCanAddOwnerReference(
-              clusterScopedResource(), clusterScopedResource());
-          ReconcilerUtils.checkIfCanAddOwnerReference(namespacedResource(), namespacedResource());
-        });
-  }
-
-  private ClusterRole clusterScopedResource() {
-    return new ClusterRoleBuilder().withMetadata(new ObjectMetaBuilder().build()).build();
-  }
-
-  private ConfigMap namespacedResource() {
-    return new ConfigMapBuilder()
-        .withMetadata(new ObjectMetaBuilder().withNamespace("testns1").build())
-        .build();
-  }
-
-  private ConfigMap namespacedResourceFromOtherNamespace() {
-    return new ConfigMapBuilder()
-        .withMetadata(new ObjectMetaBuilder().withNamespace("testns2").build())
-        .build();
   }
 
   @Group("tomcatoperator.io")

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/monitoring/AggregatedMetricsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/monitoring/AggregatedMetricsTest.java
@@ -1,0 +1,180 @@
+package io.javaoperatorsdk.operator.api.monitoring;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
+import io.javaoperatorsdk.operator.processing.Controller;
+import io.javaoperatorsdk.operator.processing.event.Event;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class AggregatedMetricsTest {
+
+  private final Metrics metrics1 = mock();
+  private final Metrics metrics2 = mock();
+  private final Metrics metrics3 = mock();
+  private final Controller<HasMetadata> controller = mock();
+  private final Event event = mock();
+  private final HasMetadata resource = mock();
+  private final RetryInfo retryInfo = mock();
+  private final ResourceID resourceID = mock();
+  private final Metrics.ControllerExecution<String> controllerExecution = mock();
+
+  private final Map<String, Object> metadata = Map.of("kind", "TestResource");
+  private final AggregatedMetrics aggregatedMetrics =
+      new AggregatedMetrics(List.of(metrics1, metrics2, metrics3));
+
+  @Test
+  void constructor_shouldThrowNullPointerExceptionWhenMetricsListIsNull() {
+    assertThatThrownBy(() -> new AggregatedMetrics(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("metricsList must not be null");
+  }
+
+  @Test
+  void constructor_shouldThrowIllegalArgumentExceptionWhenMetricsListIsEmpty() {
+    assertThatThrownBy(() -> new AggregatedMetrics(List.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("metricsList must contain at least one Metrics instance");
+  }
+
+  @Test
+  void controllerRegistered_shouldDelegateToAllMetricsInOrder() {
+    aggregatedMetrics.controllerRegistered(controller);
+
+    final var inOrder = inOrder(metrics1, metrics2, metrics3);
+    inOrder.verify(metrics1).controllerRegistered(controller);
+    inOrder.verify(metrics2).controllerRegistered(controller);
+    inOrder.verify(metrics3).controllerRegistered(controller);
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void receivedEvent_shouldDelegateToAllMetricsInOrder() {
+    aggregatedMetrics.receivedEvent(event, metadata);
+
+    final var inOrder = inOrder(metrics1, metrics2, metrics3);
+    inOrder.verify(metrics1).receivedEvent(event, metadata);
+    inOrder.verify(metrics2).receivedEvent(event, metadata);
+    inOrder.verify(metrics3).receivedEvent(event, metadata);
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void reconcileCustomResource_shouldDelegateToAllMetricsInOrder() {
+    aggregatedMetrics.reconcileCustomResource(resource, retryInfo, metadata);
+
+    final var inOrder = inOrder(metrics1, metrics2, metrics3);
+    inOrder.verify(metrics1).reconcileCustomResource(resource, retryInfo, metadata);
+    inOrder.verify(metrics2).reconcileCustomResource(resource, retryInfo, metadata);
+    inOrder.verify(metrics3).reconcileCustomResource(resource, retryInfo, metadata);
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void failedReconciliation_shouldDelegateToAllMetricsInOrder() {
+    final var exception = new RuntimeException("Test exception");
+
+    aggregatedMetrics.failedReconciliation(resource, exception, metadata);
+
+    final var inOrder = inOrder(metrics1, metrics2, metrics3);
+    inOrder.verify(metrics1).failedReconciliation(resource, exception, metadata);
+    inOrder.verify(metrics2).failedReconciliation(resource, exception, metadata);
+    inOrder.verify(metrics3).failedReconciliation(resource, exception, metadata);
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void reconciliationExecutionStarted_shouldDelegateToAllMetricsInOrder() {
+    aggregatedMetrics.reconciliationExecutionStarted(resource, metadata);
+
+    final var inOrder = inOrder(metrics1, metrics2, metrics3);
+    inOrder.verify(metrics1).reconciliationExecutionStarted(resource, metadata);
+    inOrder.verify(metrics2).reconciliationExecutionStarted(resource, metadata);
+    inOrder.verify(metrics3).reconciliationExecutionStarted(resource, metadata);
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void reconciliationExecutionFinished_shouldDelegateToAllMetricsInOrder() {
+    aggregatedMetrics.reconciliationExecutionFinished(resource, metadata);
+
+    final var inOrder = inOrder(metrics1, metrics2, metrics3);
+    inOrder.verify(metrics1).reconciliationExecutionFinished(resource, metadata);
+    inOrder.verify(metrics2).reconciliationExecutionFinished(resource, metadata);
+    inOrder.verify(metrics3).reconciliationExecutionFinished(resource, metadata);
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void cleanupDoneFor_shouldDelegateToAllMetricsInOrder() {
+    aggregatedMetrics.cleanupDoneFor(resourceID, metadata);
+
+    final var inOrder = inOrder(metrics1, metrics2, metrics3);
+    inOrder.verify(metrics1).cleanupDoneFor(resourceID, metadata);
+    inOrder.verify(metrics2).cleanupDoneFor(resourceID, metadata);
+    inOrder.verify(metrics3).cleanupDoneFor(resourceID, metadata);
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void finishedReconciliation_shouldDelegateToAllMetricsInOrder() {
+    aggregatedMetrics.finishedReconciliation(resource, metadata);
+
+    final var inOrder = inOrder(metrics1, metrics2, metrics3);
+    inOrder.verify(metrics1).finishedReconciliation(resource, metadata);
+    inOrder.verify(metrics2).finishedReconciliation(resource, metadata);
+    inOrder.verify(metrics3).finishedReconciliation(resource, metadata);
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void timeControllerExecution_shouldOnlyDelegateToFirstMetrics() throws Exception {
+    final var expectedResult = "execution result";
+    when(metrics1.timeControllerExecution(controllerExecution)).thenReturn(expectedResult);
+
+    final var result = aggregatedMetrics.timeControllerExecution(controllerExecution);
+
+    assertThat(result).isEqualTo(expectedResult);
+    verify(metrics1).timeControllerExecution(controllerExecution);
+    verify(metrics2, never()).timeControllerExecution(any());
+    verify(metrics3, never()).timeControllerExecution(any());
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void timeControllerExecution_shouldPropagateException() throws Exception {
+    final var expectedException = new RuntimeException("Controller execution failed");
+    when(metrics1.timeControllerExecution(controllerExecution)).thenThrow(expectedException);
+
+    assertThatThrownBy(() -> aggregatedMetrics.timeControllerExecution(controllerExecution))
+        .isSameAs(expectedException);
+
+    verify(metrics1).timeControllerExecution(controllerExecution);
+    verify(metrics2, never()).timeControllerExecution(any());
+    verify(metrics3, never()).timeControllerExecution(any());
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+
+  @Test
+  void monitorSizeOf_shouldDelegateToAllMetricsInOrderAndReturnOriginalMap() {
+    final var testMap = Map.of("key1", "value1");
+    final var mapName = "testMap";
+
+    final var result = aggregatedMetrics.monitorSizeOf(testMap, mapName);
+
+    assertThat(result).isSameAs(testMap);
+    verify(metrics1).monitorSizeOf(testMap, mapName);
+    verify(metrics2).monitorSizeOf(testMap, mapName);
+    verify(metrics3).monitorSizeOf(testMap, mapName);
+    verifyNoMoreInteractions(metrics1, metrics2, metrics3);
+  }
+}

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/HasKubernetesClient.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/HasKubernetesClient.java
@@ -3,5 +3,20 @@ package io.javaoperatorsdk.operator.junit;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 public interface HasKubernetesClient {
+  /**
+   * Returns the main Kubernetes client that is used to deploy the operator to the cluster.
+   *
+   * @return the main Kubernetes client
+   */
   KubernetesClient getKubernetesClient();
+
+  /**
+   * Returns the Kubernetes client that is used to deploy infrastructure resources to the cluster
+   * such as clusterroles, clusterrolebindings, etc. This client can be different from the main
+   * client in case you need to test the operator with a different restrictions more closely
+   * resembling the real restrictions it will have in production.
+   *
+   * @return the infrastructure Kubernetes client
+   */
+  KubernetesClient getInfrastructureKubernetesClient();
 }

--- a/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
+++ b/operator-framework-junit5/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
@@ -66,6 +66,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
       boolean waitForNamespaceDeletion,
       boolean oneNamespacePerClass,
       KubernetesClient kubernetesClient,
+      KubernetesClient infrastructureKubernetesClient,
       Consumer<ConfigurationServiceOverrider> configurationServiceOverrider,
       Function<ExtensionContext, String> namespaceNameSupplier,
       Function<ExtensionContext, String> perClassNamespaceNameSupplier,
@@ -78,6 +79,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
         preserveNamespaceOnError,
         waitForNamespaceDeletion,
         kubernetesClient,
+        infrastructureKubernetesClient,
         namespaceNameSupplier,
         perClassNamespaceNameSupplier);
     this.reconcilers = reconcilers;
@@ -240,7 +242,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
   protected void before(ExtensionContext context) {
     super.before(context);
 
-    final var kubernetesClient = getKubernetesClient();
+    final var kubernetesClient = getInfrastructureKubernetesClient();
 
     for (var ref : portForwards) {
       String podName =
@@ -313,7 +315,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
   protected void after(ExtensionContext context) {
     super.after(context);
 
-    var kubernetesClient = getKubernetesClient();
+    var kubernetesClient = getInfrastructureKubernetesClient();
 
     var iterator = appliedCRDs.iterator();
     while (iterator.hasNext()) {
@@ -365,6 +367,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
     private final List<String> additionalCRDs = new ArrayList<>();
     private Consumer<LocallyRunOperatorExtension> beforeStartHook;
     private KubernetesClient kubernetesClient;
+    private KubernetesClient infrastructureKubernetesClient;
 
     protected Builder() {
       super();
@@ -419,6 +422,12 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
       return this;
     }
 
+    public Builder withInfrastructureKubernetesClient(
+        KubernetesClient infrastructureKubernetesClient) {
+      this.infrastructureKubernetesClient = infrastructureKubernetesClient;
+      return this;
+    }
+
     public Builder withAdditionalCustomResourceDefinition(
         Class<? extends CustomResource> customResource) {
       additionalCustomResourceDefinitions.add(customResource);
@@ -452,6 +461,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
           waitForNamespaceDeletion,
           oneNamespacePerClass,
           kubernetesClient,
+          infrastructureKubernetesClient,
           configurationServiceOverrider,
           namespaceNameSupplier,
           perClassNamespaceNameSupplier,

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/fieldselector/FieldSelectorIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/fieldselector/FieldSelectorIT.java
@@ -1,0 +1,73 @@
+package io.javaoperatorsdk.operator.baseapi.fieldselector;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+
+import static io.javaoperatorsdk.operator.baseapi.fieldselector.FieldSelectorTestReconciler.MY_SECRET_TYPE;
+import static io.javaoperatorsdk.operator.baseapi.fieldselector.FieldSelectorTestReconciler.OTHER_SECRET_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class FieldSelectorIT {
+
+  public static final String TEST_1 = "test1";
+  public static final String TEST_2 = "test2";
+  public static final String TEST_3 = "test3";
+
+  @RegisterExtension
+  LocallyRunOperatorExtension extension =
+      LocallyRunOperatorExtension.builder()
+          .withReconciler(new FieldSelectorTestReconciler())
+          .build();
+
+  @Test
+  void filtersCustomResourceByLabel() {
+
+    var customPrimarySecret =
+        extension.create(
+            new SecretBuilder()
+                .withMetadata(new ObjectMetaBuilder().withName(TEST_1).build())
+                .withType(MY_SECRET_TYPE)
+                .build());
+
+    var otherSecret =
+        extension.create(
+            new SecretBuilder()
+                .withMetadata(new ObjectMetaBuilder().withName(TEST_2).build())
+                .build());
+
+    var dependentSecret =
+        extension.create(
+            new SecretBuilder()
+                .withMetadata(new ObjectMetaBuilder().withName(TEST_3).build())
+                .withType(OTHER_SECRET_TYPE)
+                .build());
+
+    await()
+        .pollDelay(Duration.ofMillis(150))
+        .untilAsserted(
+            () -> {
+              var r = extension.getReconcilerOfType(FieldSelectorTestReconciler.class);
+              assertThat(r.getReconciledSecrets()).containsExactly(TEST_1);
+
+              assertThat(
+                      r.getDependentSecretEventSource()
+                          .get(ResourceID.fromResource(dependentSecret)))
+                  .isPresent();
+              assertThat(
+                      r.getDependentSecretEventSource()
+                          .get(ResourceID.fromResource(customPrimarySecret)))
+                  .isNotPresent();
+              assertThat(
+                      r.getDependentSecretEventSource().get(ResourceID.fromResource(otherSecret)))
+                  .isNotPresent();
+            });
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/fieldselector/FieldSelectorTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/fieldselector/FieldSelectorTestReconciler.java
@@ -1,0 +1,69 @@
+package io.javaoperatorsdk.operator.baseapi.fieldselector;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.javaoperatorsdk.operator.api.config.informer.Field;
+import io.javaoperatorsdk.operator.api.config.informer.FieldSelectorBuilder;
+import io.javaoperatorsdk.operator.api.config.informer.Informer;
+import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
+import io.javaoperatorsdk.operator.support.TestExecutionInfoProvider;
+
+@ControllerConfiguration(
+    informer =
+        @Informer(
+            fieldSelector =
+                @Field(path = "type", value = FieldSelectorTestReconciler.MY_SECRET_TYPE)))
+public class FieldSelectorTestReconciler implements Reconciler<Secret>, TestExecutionInfoProvider {
+
+  public static final String MY_SECRET_TYPE = "my-secret-type";
+  public static final String OTHER_SECRET_TYPE = "my-dependent-secret-type";
+  private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
+
+  private Set<String> reconciledSecrets = Collections.synchronizedSet(new HashSet<>());
+  private InformerEventSource<Secret, Secret> dependentSecretEventSource;
+
+  @Override
+  public UpdateControl<Secret> reconcile(Secret resource, Context<Secret> context) {
+    reconciledSecrets.add(resource.getMetadata().getName());
+    numberOfExecutions.addAndGet(1);
+    return UpdateControl.noUpdate();
+  }
+
+  public int getNumberOfExecutions() {
+    return numberOfExecutions.get();
+  }
+
+  public Set<String> getReconciledSecrets() {
+    return reconciledSecrets;
+  }
+
+  @Override
+  public List<EventSource<?, Secret>> prepareEventSources(EventSourceContext<Secret> context) {
+    dependentSecretEventSource =
+        new InformerEventSource<>(
+            InformerEventSourceConfiguration.from(Secret.class, Secret.class)
+                .withNamespacesInheritedFromController()
+                .withFieldSelector(
+                    new FieldSelectorBuilder().withField("type", OTHER_SECRET_TYPE).build())
+                .build(),
+            context);
+
+    return List.of(dependentSecretEventSource);
+  }
+
+  public InformerEventSource<Secret, Secret> getDependentSecretEventSource() {
+    return dependentSecretEventSource;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/infrastructureclient/InfrastructureClientIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/infrastructureclient/InfrastructureClientIT.java
@@ -1,0 +1,134 @@
+package io.javaoperatorsdk.operator.baseapi.infrastructureclient;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.javaoperatorsdk.operator.ReconcilerUtils;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+class InfrastructureClientIT {
+
+  private static final String RBAC_TEST_ROLE = "rbac-test-role.yaml";
+  private static final String RBAC_TEST_ROLE_BINDING = "rbac-test-role-binding.yaml";
+  private static final String RBAC_TEST_USER = "rbac-test-user";
+
+  @RegisterExtension
+  LocallyRunOperatorExtension operator =
+      LocallyRunOperatorExtension.builder()
+          .withReconciler(new InfrastructureClientTestReconciler())
+          .withKubernetesClient(
+              new KubernetesClientBuilder()
+                  .withConfig(new ConfigBuilder().withImpersonateUsername(RBAC_TEST_USER).build())
+                  .build())
+          .withInfrastructureKubernetesClient(
+              new KubernetesClientBuilder().build()) // no limitations
+          .build();
+
+  /**
+   * We need to apply the cluster role also before the CRD deployment so the rbac-test-user is
+   * permitted to deploy it
+   */
+  public InfrastructureClientIT() {
+    applyClusterRole(RBAC_TEST_ROLE);
+    applyClusterRoleBinding(RBAC_TEST_ROLE_BINDING);
+  }
+
+  @BeforeEach
+  void setup() {
+    applyClusterRole(RBAC_TEST_ROLE);
+    applyClusterRoleBinding(RBAC_TEST_ROLE_BINDING);
+  }
+
+  @AfterEach
+  void cleanup() {
+    removeClusterRoleBinding(RBAC_TEST_ROLE_BINDING);
+    removeClusterRole(RBAC_TEST_ROLE);
+  }
+
+  @Test
+  void canCreateInfrastructure() {
+    var resource = new InfrastructureClientTestCustomResource();
+    resource.setMetadata(
+        new ObjectMetaBuilder().withName("infrastructure-client-resource").build());
+    operator.create(resource);
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              InfrastructureClientTestCustomResource r =
+                  operator.get(
+                      InfrastructureClientTestCustomResource.class,
+                      "infrastructure-client-resource");
+              assertThat(r).isNotNull();
+            });
+
+    assertThat(
+            operator
+                .getReconcilerOfType(InfrastructureClientTestReconciler.class)
+                .getNumberOfExecutions())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotAccessNotPermittedResources() {
+    assertThatThrownBy(
+            () ->
+                operator
+                    .getKubernetesClient()
+                    .apiextensions()
+                    .v1()
+                    .customResourceDefinitions()
+                    .list())
+        .isInstanceOf(KubernetesClientException.class)
+        .hasMessageContaining(
+            "User \"%s\" cannot list resource \"customresourcedefinitions\""
+                .formatted(RBAC_TEST_USER));
+
+    // but we should be able to access all resources with the infrastructure client
+    var deploymentList =
+        operator
+            .getInfrastructureKubernetesClient()
+            .apiextensions()
+            .v1()
+            .customResourceDefinitions()
+            .list();
+    assertThat(deploymentList).isNotNull();
+  }
+
+  private void applyClusterRoleBinding(String filename) {
+    var clusterRoleBinding =
+        ReconcilerUtils.loadYaml(ClusterRoleBinding.class, this.getClass(), filename);
+    operator.getInfrastructureKubernetesClient().resource(clusterRoleBinding).serverSideApply();
+  }
+
+  private void applyClusterRole(String filename) {
+    var clusterRole = ReconcilerUtils.loadYaml(ClusterRole.class, this.getClass(), filename);
+    operator.getInfrastructureKubernetesClient().resource(clusterRole).serverSideApply();
+  }
+
+  private void removeClusterRoleBinding(String filename) {
+    var clusterRoleBinding =
+        ReconcilerUtils.loadYaml(ClusterRoleBinding.class, this.getClass(), filename);
+    operator.getInfrastructureKubernetesClient().resource(clusterRoleBinding).delete();
+  }
+
+  private void removeClusterRole(String filename) {
+    var clusterRole = ReconcilerUtils.loadYaml(ClusterRole.class, this.getClass(), filename);
+    operator.getInfrastructureKubernetesClient().resource(clusterRole).delete();
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/infrastructureclient/InfrastructureClientTestCustomResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/infrastructureclient/InfrastructureClientTestCustomResource.java
@@ -1,0 +1,13 @@
+package io.javaoperatorsdk.operator.baseapi.infrastructureclient;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.javaoperatorsdk")
+@Version("v1")
+@ShortNames("ict")
+public class InfrastructureClientTestCustomResource extends CustomResource<Void, Void>
+    implements Namespaced {}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/infrastructureclient/InfrastructureClientTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/infrastructureclient/InfrastructureClientTestReconciler.java
@@ -1,0 +1,37 @@
+package io.javaoperatorsdk.operator.baseapi.infrastructureclient;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.support.TestExecutionInfoProvider;
+
+@ControllerConfiguration(name = InfrastructureClientTestReconciler.TEST_RECONCILER)
+public class InfrastructureClientTestReconciler
+    implements Reconciler<InfrastructureClientTestCustomResource>, TestExecutionInfoProvider {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(InfrastructureClientTestReconciler.class);
+
+  public static final String TEST_RECONCILER = "InfrastructureClientTestReconciler";
+  private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
+
+  @Override
+  public UpdateControl<InfrastructureClientTestCustomResource> reconcile(
+      InfrastructureClientTestCustomResource resource,
+      Context<InfrastructureClientTestCustomResource> context) {
+    numberOfExecutions.addAndGet(1);
+    log.info("Reconciled for: {}", ResourceID.fromResource(resource));
+    return UpdateControl.noUpdate();
+  }
+
+  public int getNumberOfExecutions() {
+    return numberOfExecutions.get();
+  }
+}

--- a/operator-framework/src/test/resources/io/javaoperatorsdk/operator/baseapi/infrastructureclient/rbac-test-role-binding.yaml
+++ b/operator-framework/src/test/resources/io/javaoperatorsdk/operator/baseapi/infrastructureclient/rbac-test-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbac-test-role-binding
+subjects:
+  - kind: User
+    name: rbac-test-user
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: rbac-test-role
+  apiGroup: rbac.authorization.k8s.io

--- a/operator-framework/src/test/resources/io/javaoperatorsdk/operator/baseapi/infrastructureclient/rbac-test-role.yaml
+++ b/operator-framework/src/test/resources/io/javaoperatorsdk/operator/baseapi/infrastructureclient/rbac-test-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbac-test-role
+rules:
+  - apiGroups: [ "apiextensions.k8s.io"]
+    resources: [ "customresourcedefinitions" ]
+    verbs: [ "create", "update", "patch", "delete", "deletecollection" ] # explicitly don't include "list" for the test
+  - apiGroups: [ "sample.javaoperatorsdk" ]
+    resources: [ "infrastructureclienttestcustomresources" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete", "deletecollection" ]

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <fabric8-httpclient-impl.name>jdk</fabric8-httpclient-impl.name>
     <junit.version>5.13.4</junit.version>
-    <fabric8-client.version>7.3.1</fabric8-client.version>
+    <fabric8-client.version>7.4.0</fabric8-client.version>
     <slf4j.version>2.0.17</slf4j.version>
     <log4j.version>2.25.1</log4j.version>
     <mokito.version>5.19.0</mokito.version>


### PR DESCRIPTION
Improved way to add finalizers:
- Gets the resource on retry from informer cache not a separate API call, so reduces the number of Kubernetes API calls
- Caches the updated resource, making sure it is available for next reconiliation

TODO:
- check if finalizer already there when retrying
- discuss: have this as default way of adding finalizers (behind feature flag?)