### PR TITLE
improve: PrimaryToSecondayMapper test improvements

### DIFF
--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/Cluster.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/Cluster.java
@@ -9,4 +9,4 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Group("sample.javaoperatorsdk")
 @Version("v1")
 @ShortNames("clu")
-public class Cluster extends CustomResource<Void, Void> implements Namespaced {}
+public class Cluster extends CustomResource<ClusterSpec, Void> implements Namespaced {}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/ClusterSpec.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/ClusterSpec.java
@@ -1,0 +1,14 @@
+package io.javaoperatorsdk.operator.baseapi.primarytosecondary;
+
+public class ClusterSpec {
+
+  private String clusterValue;
+
+  public String getClusterValue() {
+    return clusterValue;
+  }
+
+  public void setClusterValue(String clusterValue) {
+    this.clusterValue = clusterValue;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/Job.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/Job.java
@@ -9,4 +9,4 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Group("sample.javaoperatorsdk")
 @Version("v1")
 @ShortNames("cjo")
-public class Job extends CustomResource<JobSpec, Void> implements Namespaced {}
+public class Job extends CustomResource<JobSpec, JobStatus> implements Namespaced {}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/JobReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/JobReconciler.java
@@ -17,7 +17,7 @@ import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEven
  * needed, and to show the use cases when some mechanisms would not work without that. It's not
  * intended to be a reusable code as it is, rather serves for deeper understanding of the problem.
  */
-@ControllerConfiguration()
+@ControllerConfiguration
 public class JobReconciler implements Reconciler<Job> {
 
   private static final String JOB_CLUSTER_INDEX = "job-cluster-index";

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/JobStatus.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/JobStatus.java
@@ -1,0 +1,14 @@
+package io.javaoperatorsdk.operator.baseapi.primarytosecondary;
+
+public class JobStatus {
+
+  private String valueFromCluster;
+
+  public String getValueFromCluster() {
+    return valueFromCluster;
+  }
+
+  public void setValueFromCluster(String valueFromCluster) {
+    this.valueFromCluster = valueFromCluster;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/PrimaryToSecondaryIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/PrimaryToSecondaryIT.java
@@ -16,6 +16,9 @@ class PrimaryToSecondaryIT {
   public static final String CLUSTER_NAME = "cluster1";
   public static final int MIN_DELAY = 150;
 
+  public static final String CLUSTER_VALUE = "clusterValue";
+  public static final String JOB_1 = "job1";
+
   @RegisterExtension
   LocallyRunOperatorExtension operator =
       LocallyRunOperatorExtension.builder()
@@ -32,15 +35,18 @@ class PrimaryToSecondaryIT {
     await()
         .pollDelay(Duration.ofMillis(300))
         .untilAsserted(
-            () ->
-                assertThat(
-                        operator.getReconcilerOfType(JobReconciler.class).getNumberOfExecutions())
-                    .isEqualTo(1));
+            () -> {
+              assertThat(operator.getReconcilerOfType(JobReconciler.class).getNumberOfExecutions())
+                  .isEqualTo(1);
+              var job = operator.get(Job.class, JOB_1);
+              assertThat(job.getStatus()).isNotNull();
+              assertThat(job.getStatus().getValueFromCluster()).isEqualTo(CLUSTER_VALUE);
+            });
   }
 
   public static Job job() {
     var job = new Job();
-    job.setMetadata(new ObjectMetaBuilder().withName("job1").build());
+    job.setMetadata(new ObjectMetaBuilder().withName(JOB_1).build());
     job.setSpec(new JobSpec());
     job.getSpec().setClusterName(CLUSTER_NAME);
     return job;
@@ -49,6 +55,8 @@ class PrimaryToSecondaryIT {
   public static Cluster cluster() {
     Cluster cluster = new Cluster();
     cluster.setMetadata(new ObjectMetaBuilder().withName(CLUSTER_NAME).build());
+    cluster.setSpec(new ClusterSpec());
+    cluster.getSpec().setClusterValue(CLUSTER_VALUE);
     return cluster;
   }
 }


### PR DESCRIPTION
This change showcases that changes in `Cluster` resource triggers reconiliation of Job resources.
