### PR TITLE
feat: allow DependentResourceNode creation override

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResourceFactory.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/dependent/DependentResourceFactory.java
@@ -4,6 +4,7 @@ import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.Utils;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ConfiguredDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.DependentResourceNode;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface DependentResourceFactory<
@@ -35,5 +36,14 @@ public interface DependentResourceFactory<
         Utils.instantiateAndConfigureIfNeeded(
             dependentResourceClass, DependentResource.class, null, null);
     return dr != null ? dr.resourceType() : null;
+  }
+
+  default DependentResourceNode createNodeFrom(D spec, DependentResource dependentResource) {
+    return new DependentResourceNode(
+        spec.getReconcileCondition(),
+        spec.getDeletePostCondition(),
+        spec.getReadyCondition(),
+        spec.getActivationCondition(),
+        dependentResource);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultManagedWorkflow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DefaultManagedWorkflow.java
@@ -77,12 +77,10 @@ public class DefaultManagedWorkflow<P extends HasMetadata> implements ManagedWor
     for (DependentResourceSpec<?, P, ?> spec : orderedSpecs) {
       final var dependentResource = resolve(spec, client, configuration);
       final var node =
-          new DependentResourceNode(
-              spec.getReconcileCondition(),
-              spec.getDeletePostCondition(),
-              spec.getReadyCondition(),
-              spec.getActivationCondition(),
-              dependentResource);
+          configuration
+              .getConfigurationService()
+              .dependentResourceFactory()
+              .createNodeFrom(spec, dependentResource);
       alreadyResolved.put(dependentResource.name(), node);
       spec.getDependsOn().forEach(depend -> node.addDependsOnRelation(alreadyResolved.get(depend)));
     }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DependentResourceNode.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/DependentResourceNode.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
 @SuppressWarnings("rawtypes")
-class DependentResourceNode<R, P extends HasMetadata> {
+public class DependentResourceNode<R, P extends HasMetadata> {
 
   private final List<DependentResourceNode> dependsOn = new LinkedList<>();
   private final List<DependentResourceNode> parents = new LinkedList<>();


### PR DESCRIPTION
We want to provide CDI beans in the `Condition` subclasses as requested in https://github.com/quarkiverse/quarkus-operator-sdk/issues/720. 