### PR TITLE
fix: upgrade slf4j in bootstrapped code

### DIFF
--- a/bootstrapper-maven-plugin/src/main/resources/templates/pom.xml
+++ b/bootstrapper-maven-plugin/src/main/resources/templates/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <josdk.version>{{josdkVersion}}</josdk.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <junit.version>5.9.2</junit.version>
         <log4j.version>2.20.0</log4j.version>
         <fabric8-client.version>{{fabric8Version}}</fabric8-client.version>


### PR DESCRIPTION
When you start the Runner of the bootstrapped code no logs do appear in the terminal.
Upgrading slf4j fixes this problem.