### PR TITLE
Small health check improvements

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerWrappingEventSourceHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerWrappingEventSourceHealthIndicator.java
@@ -11,11 +11,8 @@ public interface InformerWrappingEventSourceHealthIndicator<R extends HasMetadat
 
   @Override
   default Status getStatus() {
-    var nonUp =
-        informerHealthIndicators().values().stream()
-            .filter(i -> i.getStatus() != Status.HEALTHY)
-            .findAny();
-
-    return nonUp.isPresent() ? Status.UNHEALTHY : Status.HEALTHY;
+    var hasNonHealthy =
+        informerHealthIndicators().values().stream().anyMatch(i -> i.getStatus() != Status.HEALTHY);
+    return hasNonHealthy ? Status.UNHEALTHY : Status.HEALTHY;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
@@ -204,8 +204,8 @@ class InformerWrapper<T extends HasMetadata>
   public Status getStatus() {
     var status = isRunning() && hasSynced() && isWatching() ? Status.HEALTHY : Status.UNHEALTHY;
     log.debug(
-        "Informer status: {} for for type: {}, namespace: {}, details[ is running: {}, has synced:"
-            + " {}, is watching: {} ]",
+        "Informer status: {} for type: {}, namespace: {}, details [is running: {}, has synced: {},"
+            + " is watching: {}]",
         status,
         informer.getApiTypeClass().getSimpleName(),
         namespaceIdentifier,

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/timer/TimerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/timer/TimerEventSource.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.health.Status;
 import io.javaoperatorsdk.operator.processing.event.Event;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.AbstractEventSource;
@@ -75,6 +76,11 @@ public class TimerEventSource<R extends HasMetadata> extends AbstractEventSource
       timer.cancel();
       super.stop();
     }
+  }
+
+  @Override
+  public Status getStatus() {
+    return isRunning() ? Status.HEALTHY : Status.UNHEALTHY;
   }
 
   @Override

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/polling/PollingEventSourceTest.java
@@ -87,7 +87,7 @@ class PollingEventSourceTest
   }
 
   @Test
-  void updatesHealthIndicatorBasedOnExceptionsInFetcher() throws InterruptedException {
+  void updatesHealthIndicatorBasedOnExceptionsInFetcher() {
     when(resourceFetcher.fetchResources()).thenReturn(testResponseWithOneValue());
     pollingEventSource.start();
     assertThat(pollingEventSource.getStatus()).isEqualTo(Status.HEALTHY);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/timer/TimerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/timer/TimerEventSourceTest.java
@@ -1,6 +1,5 @@
 package io.javaoperatorsdk.operator.processing.event.source.timer;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -75,7 +74,7 @@ class TimerEventSourceTest
   }
 
   @Test
-  public void eventNotRegisteredIfStopped() throws IOException {
+  public void eventNotRegisteredIfStopped() {
     var resourceID = ResourceID.fromResource(TestUtils.testCustomResource());
 
     source.stop();
@@ -84,7 +83,7 @@ class TimerEventSourceTest
   }
 
   @Test
-  public void eventNotFiredIfStopped() throws IOException {
+  public void eventNotFiredIfStopped() {
     source.scheduleOnce(ResourceID.fromResource(TestUtils.testCustomResource()), PERIOD);
     source.stop();
 


### PR DESCRIPTION
We're digging into a reported operator health issue right now, and I noticed the `for for` typo in the debug log.

I also noticed a `RetryAndRescheduleTimerEventSource` with status `UNKNOWN` in the event source health indicators, caused by `TimerEventSource` not implementing the `getStatus()` method. If that was intentional (since we don't know if the actual timer tasks have been executed successfully), I can drop that commit again.