### PR TITLE
fix: register event sources when dependents are marked for deletion

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/WorkflowReconcileExecutor.java
@@ -246,6 +246,10 @@ class WorkflowReconcileExecutor<P extends HasMetadata> extends AbstractWorkflowE
     // so if the activation condition was false, this node is not meant to be deleted.
     var dependents = dependentResourceNode.getParents();
     if (activationConditionMet) {
+      // make sure we register the dependent's event source if it hasn't been added already
+      // this might be needed in corner cases such as
+      // https://github.com/operator-framework/java-operator-sdk/issues/3249
+      registerOrDeregisterEventSourceBasedOnActivation(true, dependentResourceNode);
       createOrGetResultFor(dependentResourceNode).markForDelete();
       if (dependents.isEmpty()) {
         bottomNodes.add(dependentResourceNode);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/AlwaysFailingPrecondition.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/AlwaysFailingPrecondition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
+
+/** Reconcile precondition that always fails, simulating e.g. a missing prerequisite resource. */
+public class AlwaysFailingPrecondition
+    implements Condition<ConfigMap, BulkActivationConditionCustomResource> {
+
+  @Override
+  public boolean isMet(
+      DependentResource<ConfigMap, BulkActivationConditionCustomResource> dependentResource,
+      BulkActivationConditionCustomResource primary,
+      Context<BulkActivationConditionCustomResource> context) {
+    return false;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/AlwaysTrueActivation.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/AlwaysTrueActivation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
+
+/** Activation condition that always returns true — event source should always be registered. */
+public class AlwaysTrueActivation
+    implements Condition<Secret, BulkActivationConditionCustomResource> {
+
+  @Override
+  public boolean isMet(
+      DependentResource<Secret, BulkActivationConditionCustomResource> dependentResource,
+      BulkActivationConditionCustomResource primary,
+      Context<BulkActivationConditionCustomResource> context) {
+    return true;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionCustomResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionCustomResource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Kind;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.javaoperatorsdk")
+@Version("v1")
+@Kind("BulkActivationCondition")
+public class BulkActivationConditionCustomResource extends CustomResource<Void, Void>
+    implements Namespaced {}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionIT.java
@@ -18,10 +18,12 @@ package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
 import java.time.Duration;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.javaoperatorsdk.annotation.Sample;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.javaoperatorsdk.operator.processing.event.NoEventSourceForClassException;
 
@@ -39,25 +41,37 @@ import static org.awaitility.Awaitility.await;
  *   └── SecretBulkDependentResource  (activationCondition = AlwaysTrueActivation)
  * </pre>
  *
- * <p>On first reconciliation with only a primary resource present: the ConfigMap precondition fails
- * → JOSDK calls markDependentsForDelete() → NodeDeleteExecutor fires for SecretBulkDependent →
+ * <p>On first reconciliation the ConfigMap precondition fails → JOSDK calls
+ * markDependentsForDelete() → NodeDeleteExecutor fires for SecretBulkDependent →
  * SecretBulkDependent.getSecondaryResources() calls eventSourceRetriever.getEventSourceFor() → the
  * Secret event source was never registered (NodeReconcileExecutor never ran) →
  * NoEventSourceForClassException.
  *
  * <p>This test FAILS on unfixed JOSDK, demonstrating the bug.
  */
+@Disabled("Reproducer for https://github.com/operator-framework/java-operator-sdk/issues/3249")
+@Sample(
+    tldr = "Bulk Dependent Resource with Activation Condition Bug Reproducer",
+    description =
+        """
+        Reproducer for a bug where NodeDeleteExecutor fires for a BulkDependentResource \
+        with an activationCondition before its event source has been registered, \
+        causing NoEventSourceForClassException. Triggered when a parent dependent \
+        has a failing reconcilePrecondition on first reconciliation.
+        """)
 public class BulkActivationConditionIT {
+
+  static final BulkActivationConditionReconciler reconciler =
+      new BulkActivationConditionReconciler();
 
   @RegisterExtension
   static LocallyRunOperatorExtension extension =
-      LocallyRunOperatorExtension.builder()
-          .withReconciler(new BulkActivationConditionReconciler())
-          .build();
+      LocallyRunOperatorExtension.builder().withReconciler(reconciler).build();
 
   @BeforeEach
-  void resetError() {
-    BulkActivationConditionReconciler.lastError.set(null);
+  void reset() {
+    reconciler.lastError.set(null);
+    reconciler.callCount.set(0);
   }
 
   @Test
@@ -70,21 +84,16 @@ public class BulkActivationConditionIT {
             .build());
     extension.create(primary);
 
-    // Wait for the error to arrive — the ConfigMap precondition always fails,
-    // so JOSDK should attempt NodeDeleteExecutor for the Secret bulk dependent.
-    await()
-        .atMost(Duration.ofSeconds(30))
-        .until(() -> BulkActivationConditionReconciler.lastError.get() != null);
+    // Wait for reconcile() or updateErrorStatus() to be called — whichever comes first.
+    // If the bug is present, updateErrorStatus() fires (no reconcile() call); if fixed,
+    // reconcile() runs cleanly.
+    await().atMost(Duration.ofSeconds(30)).until(() -> reconciler.callCount.get() > 0);
 
-    // On unfixed JOSDK this fails: lastError is a NoEventSourceForClassException (or wraps one).
-    // The assertion below demonstrates the bug by asserting the exception should NOT be present.
-    Exception error = BulkActivationConditionReconciler.lastError.get();
-    assertThat(error)
+    // On unfixed JOSDK this fails: lastError contains NoEventSourceForClassException.
+    assertThat(reconciler.lastError.get())
         .as(
             "NodeDeleteExecutor must not throw NoEventSourceForClassException when the"
-                + " activationCondition-gated event source was never registered."
-                + " Actual error: %s",
-            error)
+                + " activationCondition-gated event source was never registered")
         .satisfies(
             e -> {
               Throwable t = e;

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionIT.java
@@ -18,14 +18,12 @@ package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
 import java.time.Duration;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.javaoperatorsdk.annotation.Sample;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
-import io.javaoperatorsdk.operator.processing.event.NoEventSourceForClassException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -49,7 +47,6 @@ import static org.awaitility.Awaitility.await;
  *
  * <p>This test FAILS on unfixed JOSDK, demonstrating the bug.
  */
-@Disabled("Reproducer for https://github.com/operator-framework/java-operator-sdk/issues/3249")
 @Sample(
     tldr = "Bulk Dependent Resource with Activation Condition Bug Reproducer",
     description =
@@ -84,25 +81,11 @@ public class BulkActivationConditionIT {
             .build());
     extension.create(primary);
 
-    // Wait for reconcile() or updateErrorStatus() to be called — whichever comes first.
-    // If the bug is present, updateErrorStatus() fires (no reconcile() call); if fixed,
-    // reconcile() runs cleanly.
-    await().atMost(Duration.ofSeconds(30)).until(() -> reconciler.callCount.get() > 0);
+    // Wait for reconcile() to be called.
+    // If the bug is present, SecretBulkDependentResource will be in error and lastError will be set
+    await().atMost(Duration.ofSeconds(10)).until(() -> reconciler.callCount.get() == 1);
 
     // On unfixed JOSDK this fails: lastError contains NoEventSourceForClassException.
-    assertThat(reconciler.lastError.get())
-        .as(
-            "NodeDeleteExecutor must not throw NoEventSourceForClassException when the"
-                + " activationCondition-gated event source was never registered")
-        .satisfies(
-            e -> {
-              Throwable t = e;
-              while (t != null) {
-                assertThat(t)
-                    .as("Cause chain should not contain NoEventSourceForClassException")
-                    .isNotInstanceOf(NoEventSourceForClassException.class);
-                t = t.getCause();
-              }
-            });
+    assertThat(reconciler.lastError.get()).isNull();
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+import io.javaoperatorsdk.operator.processing.event.NoEventSourceForClassException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Reproducer for the bug where NodeDeleteExecutor fires for a BulkDependentResource whose
+ * activationCondition-gated event source has never been registered.
+ *
+ * <p>Workflow under test:
+ *
+ * <pre>
+ * ConfigMapDependentResource  (reconcilePrecondition = AlwaysFailingPrecondition)
+ *   └── SecretBulkDependentResource  (activationCondition = AlwaysTrueActivation)
+ * </pre>
+ *
+ * <p>On first reconciliation with only a primary resource present: the ConfigMap precondition fails
+ * → JOSDK calls markDependentsForDelete() → NodeDeleteExecutor fires for SecretBulkDependent →
+ * SecretBulkDependent.getSecondaryResources() calls eventSourceRetriever.getEventSourceFor() → the
+ * Secret event source was never registered (NodeReconcileExecutor never ran) →
+ * NoEventSourceForClassException.
+ *
+ * <p>This test FAILS on unfixed JOSDK, demonstrating the bug.
+ */
+public class BulkActivationConditionIT {
+
+  @RegisterExtension
+  static LocallyRunOperatorExtension extension =
+      LocallyRunOperatorExtension.builder()
+          .withReconciler(new BulkActivationConditionReconciler())
+          .build();
+
+  @BeforeEach
+  void resetError() {
+    BulkActivationConditionReconciler.lastError.set(null);
+  }
+
+  @Test
+  void nodeDeleteExecutorShouldNotThrowWhenEventSourceNotYetRegistered() {
+    var primary = new BulkActivationConditionCustomResource();
+    primary.setMetadata(
+        new ObjectMetaBuilder()
+            .withName("test-primary")
+            .withNamespace(extension.getNamespace())
+            .build());
+    extension.create(primary);
+
+    // Wait for the error to arrive — the ConfigMap precondition always fails,
+    // so JOSDK should attempt NodeDeleteExecutor for the Secret bulk dependent.
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> BulkActivationConditionReconciler.lastError.get() != null);
+
+    // On unfixed JOSDK this fails: lastError is a NoEventSourceForClassException (or wraps one).
+    // The assertion below demonstrates the bug by asserting the exception should NOT be present.
+    Exception error = BulkActivationConditionReconciler.lastError.get();
+    assertThat(error)
+        .as(
+            "NodeDeleteExecutor must not throw NoEventSourceForClassException when the"
+                + " activationCondition-gated event source was never registered."
+                + " Actual error: %s",
+            error)
+        .satisfies(
+            e -> {
+              Throwable t = e;
+              while (t != null) {
+                assertThat(t)
+                    .as("Cause chain should not contain NoEventSourceForClassException")
+                    .isNotInstanceOf(NoEventSourceForClassException.class);
+                t = t.getCause();
+              }
+            });
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionReconciler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.javaoperatorsdk.operator.api.reconciler.*;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+
+/**
+ * Workflow:
+ *
+ * <pre>
+ * ConfigMapDependentResource  (reconcilePrecondition = AlwaysFailingPrecondition)
+ *   └── SecretBulkDependentResource  (activationCondition = AlwaysTrueActivation)
+ * </pre>
+ *
+ * <p>On first reconciliation: ConfigMap precondition fails → markDependentsForDelete cascades to
+ * SecretBulkDependentResource → NodeDeleteExecutor fires for Secret before its event source is ever
+ * registered → NoEventSourceForClassException.
+ */
+@Workflow(
+    dependents = {
+      @Dependent(
+          name = "configmap",
+          type = ConfigMapDependentResource.class,
+          reconcilePrecondition = AlwaysFailingPrecondition.class),
+      @Dependent(
+          type = SecretBulkDependentResource.class,
+          activationCondition = AlwaysTrueActivation.class,
+          dependsOn = "configmap")
+    })
+@ControllerConfiguration
+public class BulkActivationConditionReconciler
+    implements Reconciler<BulkActivationConditionCustomResource> {
+
+  static final AtomicReference<Exception> lastError = new AtomicReference<>();
+
+  @Override
+  public UpdateControl<BulkActivationConditionCustomResource> reconcile(
+      BulkActivationConditionCustomResource primary,
+      Context<BulkActivationConditionCustomResource> context) {
+    return UpdateControl.noUpdate();
+  }
+
+  @Override
+  public ErrorStatusUpdateControl<BulkActivationConditionCustomResource> updateErrorStatus(
+      BulkActivationConditionCustomResource primary,
+      Context<BulkActivationConditionCustomResource> context,
+      Exception e) {
+    lastError.set(e);
+    return ErrorStatusUpdateControl.noStatusUpdate();
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionReconciler.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.javaoperatorsdk.operator.api.reconciler.*;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import io.javaoperatorsdk.operator.processing.retry.GradualRetry;
 
 /**
  * Workflow:
@@ -40,11 +41,14 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
           type = ConfigMapDependentResource.class,
           reconcilePrecondition = AlwaysFailingPrecondition.class),
       @Dependent(
+          name = SecretBulkDependentResource.NAME,
           type = SecretBulkDependentResource.class,
           activationCondition = AlwaysTrueActivation.class,
           dependsOn = "configmap")
-    })
-@ControllerConfiguration
+    },
+    handleExceptionsInReconciler = true)
+@GradualRetry(maxAttempts = 0)
+@ControllerConfiguration(maxReconciliationInterval = @MaxReconciliationInterval(interval = 0))
 public class BulkActivationConditionReconciler
     implements Reconciler<BulkActivationConditionCustomResource> {
 
@@ -58,17 +62,21 @@ public class BulkActivationConditionReconciler
   public UpdateControl<BulkActivationConditionCustomResource> reconcile(
       BulkActivationConditionCustomResource primary,
       Context<BulkActivationConditionCustomResource> context) {
+    final var workflowResult =
+        context
+            .managedWorkflowAndDependentResourceContext()
+            .getWorkflowReconcileResult()
+            .orElseThrow();
+    final var erroredDependents = workflowResult.getErroredDependents();
+    if (!erroredDependents.isEmpty()) {
+      final var exception =
+          erroredDependents.get(
+              workflowResult
+                  .getDependentResourceByName(SecretBulkDependentResource.NAME)
+                  .orElseThrow());
+      lastError.set(exception);
+    }
     callCount.incrementAndGet();
     return UpdateControl.noUpdate();
-  }
-
-  @Override
-  public ErrorStatusUpdateControl<BulkActivationConditionCustomResource> updateErrorStatus(
-      BulkActivationConditionCustomResource primary,
-      Context<BulkActivationConditionCustomResource> context,
-      Exception e) {
-    lastError.set(e);
-    callCount.incrementAndGet();
-    return ErrorStatusUpdateControl.noStatusUpdate();
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/BulkActivationConditionReconciler.java
@@ -15,6 +15,7 @@
  */
 package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.javaoperatorsdk.operator.api.reconciler.*;
@@ -47,12 +48,17 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
 public class BulkActivationConditionReconciler
     implements Reconciler<BulkActivationConditionCustomResource> {
 
-  static final AtomicReference<Exception> lastError = new AtomicReference<>();
+  /** Tracks how many times reconcile() or updateErrorStatus() has been called. */
+  final AtomicInteger callCount = new AtomicInteger();
+
+  /** Set when updateErrorStatus() is invoked; null means no error occurred. */
+  final AtomicReference<Exception> lastError = new AtomicReference<>();
 
   @Override
   public UpdateControl<BulkActivationConditionCustomResource> reconcile(
       BulkActivationConditionCustomResource primary,
       Context<BulkActivationConditionCustomResource> context) {
+    callCount.incrementAndGet();
     return UpdateControl.noUpdate();
   }
 
@@ -62,6 +68,7 @@ public class BulkActivationConditionReconciler
       Context<BulkActivationConditionCustomResource> context,
       Exception e) {
     lastError.set(e);
+    callCount.incrementAndGet();
     return ErrorStatusUpdateControl.noStatusUpdate();
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/ConfigMapDependentResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/ConfigMapDependentResource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+
+/**
+ * Parent dependent resource. Its reconcile precondition always fails, which causes JOSDK to call
+ * markDependentsForDelete() on its children — triggering NodeDeleteExecutor for SecretBulkDependent
+ * before that resource's event source has ever been registered.
+ */
+public class ConfigMapDependentResource
+    extends CRUDKubernetesDependentResource<ConfigMap, BulkActivationConditionCustomResource> {
+
+  @Override
+  protected ConfigMap desired(
+      BulkActivationConditionCustomResource primary,
+      Context<BulkActivationConditionCustomResource> context) {
+    var cm = new ConfigMap();
+    cm.setMetadata(
+        new ObjectMetaBuilder()
+            .withName(primary.getMetadata().getName())
+            .withNamespace(primary.getMetadata().getNamespace())
+            .build());
+    return cm;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/SecretBulkDependentResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/SecretBulkDependentResource.java
@@ -43,8 +43,9 @@ public class SecretBulkDependentResource
     extends KubernetesDependentResource<Secret, BulkActivationConditionCustomResource>
     implements CRUDKubernetesBulkDependentResource<Secret, BulkActivationConditionCustomResource> {
 
-  public static final String LABEL_KEY = "reproducer";
-  public static final String LABEL_VALUE = "bulk-activation-condition";
+  static final String NAME = "secret";
+  static final String LABEL_KEY = "reproducer";
+  static final String LABEL_VALUE = "bulk-activation-condition";
 
   @Override
   public Map<ResourceID, Secret> desiredResources(

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/SecretBulkDependentResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/bulkactivationcondition/SecretBulkDependentResource.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.workflow.bulkactivationcondition;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.ResourceIDMapper;
+import io.javaoperatorsdk.operator.processing.dependent.CRUDKubernetesBulkDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+
+/**
+ * Child bulk dependent resource with an activationCondition.
+ *
+ * <p>The bug: when NodeDeleteExecutor fires for this resource (because its parent
+ * ConfigMapDependentResource has a failing reconcilePrecondition), the event source for Secret has
+ * never been registered — NodeReconcileExecutor never ran for this node. NodeDeleteExecutor does
+ * NOT call registerOrDeregisterEventSourceBasedOnActivation() before calling delete(), so
+ * getSecondaryResources() → eventSourceRetriever.getEventSourceFor(Secret.class) throws
+ * NoEventSourceForClassException.
+ *
+ * <p>This implementation intentionally has no try/catch — it exposes the raw bug.
+ */
+public class SecretBulkDependentResource
+    extends KubernetesDependentResource<Secret, BulkActivationConditionCustomResource>
+    implements CRUDKubernetesBulkDependentResource<Secret, BulkActivationConditionCustomResource> {
+
+  public static final String LABEL_KEY = "reproducer";
+  public static final String LABEL_VALUE = "bulk-activation-condition";
+
+  @Override
+  public Map<ResourceID, Secret> desiredResources(
+      BulkActivationConditionCustomResource primary,
+      Context<BulkActivationConditionCustomResource> context) {
+    var secret = new Secret();
+    secret.setMetadata(
+        new ObjectMetaBuilder()
+            .withName(primary.getMetadata().getName())
+            .withNamespace(primary.getMetadata().getNamespace())
+            .withLabels(Map.of(LABEL_KEY, LABEL_VALUE))
+            .build());
+    return Map.of(ResourceIDMapper.kubernetesResourceIdMapper().idFor(secret), secret);
+  }
+
+  @Override
+  public Map<ResourceID, Secret> getSecondaryResources(
+      BulkActivationConditionCustomResource primary,
+      Context<BulkActivationConditionCustomResource> context) {
+    // Deliberately uses getEventSourceFor (singular) — not getSecondaryResourcesAsStream —
+    // because the singular variant throws NoEventSourceForClassException when the source is absent.
+    // This mirrors the Kroxylicious ClusterRouteDependentResource pattern and exposes the bug:
+    // on first reconciliation NodeDeleteExecutor fires before the event source is registered.
+    var secrets =
+        context
+            .eventSourceRetriever()
+            .getEventSourceFor(Secret.class)
+            .getSecondaryResources(primary);
+    return secrets.stream()
+        .collect(Collectors.toMap(ResourceID::fromResource, Function.identity()));
+  }
+}


### PR DESCRIPTION
Adds a failing integration test to reproduce the bug described in #3249.

## Workflow under test

```
ConfigMapDependentResource  (reconcilePrecondition = ALWAYS_FALSE)
  └── SecretBulkDependentResource  (activationCondition = ALWAYS_TRUE)
```

On first reconciliation the ConfigMap precondition fails → `markDependentsForDelete` cascades to `SecretBulkDependentResource` → `NodeDeleteExecutor` fires → the Secret event source was never registered (because `NodeReconcileExecutor` never ran) → `NoEventSourceForClassException`.

The test asserts this exception does **not** occur, and currently **fails**, demonstrating the bug.

I'm quite happy to attempt a fix, but didn't wanted to make sure it was confirmed as a bug first 