### PR TITLE
fix: local E2E test should not delete CRD

### DIFF
--- a/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
+++ b/sample-operators/mysql-schema/src/test/java/io/javaoperatorsdk/operator/sample/MySQLSchemaOperatorE2E.java
@@ -74,6 +74,7 @@ class MySQLSchemaOperatorE2E {
               .withReconciler(new MySQLSchemaReconciler()) // configuration for schema comes from
               // SchemaDependentResource annotation
               .withInfrastructure(infrastructure)
+              .withDeleteCRDs(false)
               .withPortForward(MY_SQL_NS, "app", "mysql", 3306, SchemaDependentResource.LOCAL_PORT)
               .build()
           : ClusterDeployedOperatorExtension.builder()

--- a/sample-operators/operations/src/test/java/io/javaoperatorsdk/operator/sample/operations/OperationsE2E.java
+++ b/sample-operators/operations/src/test/java/io/javaoperatorsdk/operator/sample/operations/OperationsE2E.java
@@ -74,6 +74,7 @@ class OperationsE2E {
           ? LocallyRunOperatorExtension.builder()
               .withReconciler(new OperationsReconciler1())
               .withReconciler(new OperationsReconciler2())
+              .withDeleteCRDs(false)
               .withConfigurationService(
                   c -> c.withMetrics(OperationsSampleOperator.initOTLPMetrics(true)))
               .build()

--- a/sample-operators/tomcat-operator/src/test/java/io/javaoperatorsdk/operator/sample/TomcatOperatorE2E.java
+++ b/sample-operators/tomcat-operator/src/test/java/io/javaoperatorsdk/operator/sample/TomcatOperatorE2E.java
@@ -61,6 +61,7 @@ class TomcatOperatorE2E {
       isLocal()
           ? LocallyRunOperatorExtension.builder()
               .waitForNamespaceDeletion(false)
+              .withDeleteCRDs(false)
               .withReconciler(new TomcatReconciler())
               .withReconciler(new WebappReconciler(client))
               .build()

--- a/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorE2E.java
+++ b/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorE2E.java
@@ -42,6 +42,7 @@ class WebPageOperatorE2E extends WebPageOperatorAbstractTest {
       isLocal()
           ? LocallyRunOperatorExtension.builder()
               .waitForNamespaceDeletion(false)
+              .withDeleteCRDs(false)
               .withReconciler(new WebPageReconciler())
               .build()
           : ClusterDeployedOperatorExtension.builder()

--- a/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorManagedDependentResourcesE2E.java
+++ b/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorManagedDependentResourcesE2E.java
@@ -40,6 +40,7 @@ class WebPageOperatorManagedDependentResourcesE2E extends WebPageOperatorAbstrac
       isLocal()
           ? LocallyRunOperatorExtension.builder()
               .waitForNamespaceDeletion(false)
+              .withDeleteCRDs(false)
               .withReconciler(new WebPageManagedDependentsReconciler())
               .build()
           : ClusterDeployedOperatorExtension.builder()

--- a/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorStandaloneDependentResourcesE2E.java
+++ b/sample-operators/webpage/src/test/java/io/javaoperatorsdk/operator/sample/WebPageOperatorStandaloneDependentResourcesE2E.java
@@ -33,6 +33,7 @@ class WebPageOperatorStandaloneDependentResourcesE2E extends WebPageOperatorAbst
       isLocal()
           ? LocallyRunOperatorExtension.builder()
               .waitForNamespaceDeletion(false)
+              .withDeleteCRDs(false)
               .withReconciler(new WebPageStandaloneDependentsReconciler())
               .build()
           : ClusterDeployedOperatorExtension.builder()


### PR DESCRIPTION
That causes a race condition, where it marks the CRD to be deleted.
But since we don't wait for cleanup of the namespace in E2E eventually the
namespace is deleted by garbage collector and then the CRD is deleted.
Unfortunatelly this can happen when the cluster test is already running.

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
