### PR TITLE
improve: deprecated isWatching method for informers health indicator

### DIFF
--- a/docs/content/en/docs/documentation/operations/health-probes.md
+++ b/docs/content/en/docs/documentation/operations/health-probes.md
@@ -17,7 +17,7 @@ API.
 | `isStarted()` | `true` once the operator and all its controllers have fully started |
 | `allEventSourcesAreHealthy()` | `true` when every registered event source (informers, polling sources, etc.) reports a healthy status |
 | `unhealthyEventSources()` | returns a map of controller name → unhealthy event sources, useful for diagnostics |
-| `unhealthyInformerWrappingEventSourceHealthIndicator()` | returns a map of controller name → unhealthy informer-wrapping event sources, each exposing per-informer details via `InformerHealthIndicator` (`hasSynced()`, `isWatching()`, `isRunning()`, `getTargetNamespace()`) |
+| `unhealthyInformerWrappingEventSourceHealthIndicator()` | returns a map of controller name → unhealthy informer-wrapping event sources, each exposing per-informer details via `InformerHealthIndicator` (`hasSynced()`, `isRunning()`, `getTargetNamespace()`) |
 
 In most cases a single readiness probe backed by `allEventSourcesAreHealthy()` is sufficient: before the
 operator has fully started the informers will not have synced yet, so the check naturally covers the startup
@@ -27,7 +27,7 @@ case as well. Once running, it detects runtime degradation such as a lost watch 
 
 For advanced use cases — such as exposing per-informer health in a diagnostic endpoint or logging which
 specific namespace lost its watch — `unhealthyInformerWrappingEventSourceHealthIndicator()` gives access to
-individual `InformerHealthIndicator` instances. Each indicator exposes `hasSynced()`, `isWatching()`,
+individual `InformerHealthIndicator` instances. Each indicator exposes `hasSynced()`,
 `isRunning()`, and `getTargetNamespace()`. This is typically not needed for a standard health probe but can
 be valuable for operational dashboards or troubleshooting.
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
@@ -20,8 +20,8 @@ public interface InformerHealthIndicator extends EventSourceHealthIndicator {
   boolean hasSynced();
 
   /**
-   * @deprecated this method is not suitable for health check, it is expected
-   * that the watches sometimes fail.
+   * @deprecated this method is not suitable for health check, it is expected that the watches
+   *     sometimes fail.
    * @return if the watch is established at the moment.
    */
   @Deprecated(forRemoval = true)

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/health/InformerHealthIndicator.java
@@ -19,6 +19,12 @@ public interface InformerHealthIndicator extends EventSourceHealthIndicator {
 
   boolean hasSynced();
 
+  /**
+   * @deprecated this method is not suitable for health check, it is expected
+   * that the watches sometimes fail.
+   * @return if the watch is established at the moment.
+   */
+  @Deprecated(forRemoval = true)
   boolean isWatching();
 
   boolean isRunning();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerWrapper.java
@@ -210,6 +210,7 @@ class InformerWrapper<T extends HasMetadata>
   }
 
   @Override
+  @Deprecated(forRemoval = true)
   public boolean isWatching() {
     return informer.isWatching();
   }


### PR DESCRIPTION
This method is not suitable as a health indicator

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
