### PR TITLE
fix: mockito and OpenJDK warning when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,7 @@
           <version>${maven-surefire-plugin.version}</version>
           <!-- Summary output for tests at the end -->
           <configuration>
+            <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mokito.version}/mockito-core-${mokito.version}.jar -Xshare:off</argLine>
             <reportFormat>plain</reportFormat>
             <consoleOutputReporter>
               <disable>true</disable>


### PR DESCRIPTION
Warnings:
```txt
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
WARNING: A Java agent has been loaded dynamically (/Users/attila/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
```
Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
