### PR TITLE
improve: deprecate instance based Mappers.fromOwnerReferences

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
@@ -87,12 +87,18 @@ public class Mappers {
         clusterScoped);
   }
 
+  /**
+   * @deprecated use {@link #fromOwnerReferences(Class)}
+   */
   @Deprecated(forRemoval = true)
   public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromOwnerReferences(
       HasMetadata primaryResource) {
     return fromOwnerReferences(primaryResource, false);
   }
 
+  /**
+   * @deprecated use {@link #fromOwnerReferences(Class,boolean)}
+   */
   @Deprecated(forRemoval = true)
   public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromOwnerReferences(
       HasMetadata primaryResource, boolean clusterScoped) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
@@ -87,11 +87,13 @@ public class Mappers {
         clusterScoped);
   }
 
+  @Deprecated(forRemoval = true)
   public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromOwnerReferences(
       HasMetadata primaryResource) {
     return fromOwnerReferences(primaryResource, false);
   }
 
+  @Deprecated(forRemoval = true)
   public static <T extends HasMetadata> SecondaryToPrimaryMapper<T> fromOwnerReferences(
       HasMetadata primaryResource, boolean clusterScoped) {
     return fromOwnerReferences(


### PR DESCRIPTION
This does not make sense to me, this should be always based on class

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
