### PR TITLE
feat(core): add by-name secondary resource lookup on Context

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
@@ -114,6 +114,89 @@ public interface Context<P extends HasMetadata> {
 
   <R> Optional<R> getSecondaryResource(Class<R> expectedType, String eventSourceName);
 
+  /**
+   * Retrieves a specific secondary resource by name and namespace from the event source identified
+   * by the given name.
+   *
+   * <p>This is a typed convenience over manually retrieving the {@link
+   * io.javaoperatorsdk.operator.processing.event.source.EventSource} and calling its cache. When
+   * the underlying event source implements {@link
+   * io.javaoperatorsdk.operator.processing.event.source.Cache}, the lookup is a direct cache lookup
+   * and read-cache-after-write consistent.
+   *
+   * <p>{@code eventSourceName} may be {@code null}. When {@code null} and {@code expectedType} is
+   * part of a managed workflow whose activation condition may not have registered the event source,
+   * an empty {@link Optional} is returned instead of throwing {@link
+   * io.javaoperatorsdk.operator.processing.event.NoEventSourceForClassException}.
+   *
+   * @param expectedType the class representing the type of secondary resource to retrieve
+   * @param eventSourceName the name of the event source to look in (may be {@code null})
+   * @param name the name of the secondary resource
+   * @param namespace the namespace of the secondary resource (may be {@code null} for
+   *     cluster-scoped resources)
+   * @param <R> the type of secondary resource to retrieve
+   * @return an {@link Optional} containing the matching secondary resource, or {@link
+   *     Optional#empty()} if none matches
+   * @throws io.javaoperatorsdk.operator.processing.event.NoEventSourceForClassException if no event
+   *     source is registered for the given type and name (and no workflow activation condition
+   *     accounts for it)
+   * @since 5.4.0
+   */
+  <R extends HasMetadata> Optional<R> getSecondaryResource(
+      Class<R> expectedType, String eventSourceName, String name, String namespace);
+
+  /**
+   * Convenience overload of {@link #getSecondaryResource(Class, String, String, String)} that uses
+   * the primary resource's namespace.
+   *
+   * <p>If the primary resource is cluster-scoped (no namespace), the lookup is performed against
+   * the cluster scope. To target a specific namespace from a cluster-scoped primary, use {@link
+   * #getSecondaryResource(Class, String, String, String)} directly.
+   *
+   * <p>{@code eventSourceName} may be {@code null} with the same semantics as in {@link
+   * #getSecondaryResource(Class, String, String, String)}.
+   *
+   * @param expectedType the class representing the type of secondary resource to retrieve
+   * @param eventSourceName the name of the event source to look in (may be {@code null})
+   * @param name the name of the secondary resource (namespace inferred from the primary)
+   * @param <R> the type of secondary resource to retrieve
+   * @return an {@link Optional} containing the matching secondary resource, or {@link
+   *     Optional#empty()} if none matches
+   * @since 5.4.0
+   */
+  default <R extends HasMetadata> Optional<R> getSecondaryResource(
+      Class<R> expectedType, String eventSourceName, String name) {
+    return getSecondaryResource(
+        expectedType, eventSourceName, name, getPrimaryResource().getMetadata().getNamespace());
+  }
+
+  /**
+   * Retrieves a {@link Stream} of the secondary resources of the specified type from the event
+   * source identified by the given name. Useful when several event sources are registered for the
+   * same type and you need to scope retrieval to one of them, or when you want to apply a custom
+   * filter at the call site.
+   *
+   * <p>When the underlying event source implements {@link ResourceCache}, the stream is
+   * read-cache-after-write consistent.
+   *
+   * <p>{@code eventSourceName} may be {@code null} with the same semantics as in {@link
+   * #getSecondaryResource(Class, String, String, String)}: when {@code null} and {@code
+   * expectedType} is part of a managed workflow whose activation condition may not have registered
+   * the event source, an empty {@link Stream} is returned instead of throwing {@link
+   * io.javaoperatorsdk.operator.processing.event.NoEventSourceForClassException}.
+   *
+   * @param expectedType the class representing the type of secondary resources to retrieve
+   * @param eventSourceName the name of the event source to look in (may be {@code null})
+   * @param <R> the type of secondary resources to retrieve
+   * @return a {@link Stream} of secondary resources of the specified type
+   * @throws io.javaoperatorsdk.operator.processing.event.NoEventSourceForClassException if no event
+   *     source is registered for the given type and name (and no workflow activation condition
+   *     accounts for it)
+   * @since 5.4.0
+   */
+  <R extends HasMetadata> Stream<R> getSecondaryResourcesAsStream(
+      Class<R> expectedType, String eventSourceName);
+
   ControllerConfiguration<P> getControllerConfiguration();
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
@@ -36,6 +36,7 @@ import io.javaoperatorsdk.operator.processing.Controller;
 import io.javaoperatorsdk.operator.processing.event.EventSourceRetriever;
 import io.javaoperatorsdk.operator.processing.event.NoEventSourceForClassException;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.Cache;
 
 public class DefaultContext<P extends HasMetadata> implements Context<P> {
   private RetryInfo retryInfo;
@@ -95,6 +96,20 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
     }
   }
 
+  /**
+   * Whether a missing event source for the given type is the expected case, in which case callers
+   * should return an empty result instead of propagating the {@link
+   * NoEventSourceForClassException}.
+   *
+   * <p>If a workflow has an activation condition there can be event sources which are only
+   * registered if the activation condition holds, but to provide a consistent API we return an
+   * empty result instead of throwing an exception. Note that not only the resource which has an
+   * activation condition might not be registered but dependents which depend on it.
+   */
+  private boolean isMissingEventSourceExpected(String eventSourceName, Class<?> expectedType) {
+    return eventSourceName == null && controller.workflowContainsDependentForType(expectedType);
+  }
+
   private <R> Map<ResourceID, R> deduplicatedMap(Stream<R> stream) {
     return stream.collect(
         Collectors.toUnmodifiableMap(
@@ -120,19 +135,51 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
           .getEventSourceFor(expectedType, eventSourceName)
           .getSecondaryResource(primaryResource);
     } catch (NoEventSourceForClassException e) {
-      /*
-       * If a workflow has an activation condition there can be event sources which are only
-       * registered if the activation condition holds, but to provide a consistent API we return an
-       * Optional instead of throwing an exception.
-       *
-       * Note that not only the resource which has an activation condition might not be registered
-       * but dependents which depend on it.
-       */
-      if (eventSourceName == null && controller.workflowContainsDependentForType(expectedType)) {
+      if (isMissingEventSourceExpected(eventSourceName, expectedType)) {
         return Optional.empty();
-      } else {
-        throw e;
       }
+      throw e;
+    }
+  }
+
+  @Override
+  public <R extends HasMetadata> Optional<R> getSecondaryResource(
+      Class<R> expectedType, String eventSourceName, String name, String namespace) {
+    try {
+      final var eventSource =
+          controller.getEventSourceManager().getEventSourceFor(expectedType, eventSourceName);
+      final var resourceID = new ResourceID(name, namespace);
+      if (eventSource instanceof Cache<?> cache) {
+        return cache.get(resourceID).map(expectedType::cast);
+      }
+      return eventSource.getSecondaryResources(primaryResource).stream()
+          .filter(r -> ResourceID.fromResource(r).equals(resourceID))
+          .findFirst();
+    } catch (NoEventSourceForClassException e) {
+      if (isMissingEventSourceExpected(eventSourceName, expectedType)) {
+        return Optional.empty();
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public <R extends HasMetadata> Stream<R> getSecondaryResourcesAsStream(
+      Class<R> expectedType, String eventSourceName) {
+    try {
+      final var eventSource =
+          controller.getEventSourceManager().getEventSourceFor(expectedType, eventSourceName);
+      if (eventSource instanceof ResourceCache<?> resourceCache) {
+        final var ns = primaryResource.getMetadata().getNamespace();
+        final Stream<?> stream = ns == null ? resourceCache.list() : resourceCache.list(ns);
+        return stream.map(expectedType::cast);
+      }
+      return eventSource.getSecondaryResources(primaryResource).stream();
+    } catch (NoEventSourceForClassException e) {
+      if (isMissingEventSourceExpected(eventSourceName, expectedType)) {
+        return Stream.empty();
+      }
+      throw e;
     }
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContextTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContextTest.java
@@ -16,26 +16,34 @@
 package io.javaoperatorsdk.operator.api.reconciler;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.javaoperatorsdk.operator.processing.Controller;
 import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
 import io.javaoperatorsdk.operator.processing.event.NoEventSourceForClassException;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.source.informer.ManagedInformerEventSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DefaultContextTest {
@@ -60,6 +68,234 @@ class DefaultContextTest {
         .thenThrow(new NoEventSourceForClassException(ConfigMap.class));
 
     var res = context.getSecondaryResource(ConfigMap.class);
+    assertThat(res).isEmpty();
+  }
+
+  @Test
+  void getSecondaryResourceByNameAndNamespaceReturnsFromCacheFastPath() {
+    final var cm =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("cm-foo")
+            .withNamespace("ns")
+            .endMetadata()
+            .build();
+
+    final ManagedInformerEventSource<ConfigMap, HasMetadata, ?> cachingEventSource = mock();
+    when(cachingEventSource.get(new ResourceID("cm-foo", "ns"))).thenReturn(Optional.of(cm));
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name")).thenReturn(cachingEventSource);
+
+    final var res = context.getSecondaryResource(ConfigMap.class, "es-name", "cm-foo", "ns");
+
+    assertThat(res).contains(cm);
+    verify(cachingEventSource).get(new ResourceID("cm-foo", "ns"));
+  }
+
+  @Test
+  void getSecondaryResourceByNameAndNamespaceReturnsEmptyOnCacheMiss() {
+    final ManagedInformerEventSource<ConfigMap, HasMetadata, ?> cachingEventSource = mock();
+    when(cachingEventSource.get(new ResourceID("missing", "ns"))).thenReturn(Optional.empty());
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name")).thenReturn(cachingEventSource);
+
+    assertThat(context.getSecondaryResource(ConfigMap.class, "es-name", "missing", "ns")).isEmpty();
+  }
+
+  @Test
+  void getSecondaryResourceByNameAndNamespaceFallsBackToGetSecondaryResources() {
+    final var match =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("cm-foo")
+            .withNamespace("ns")
+            .endMetadata()
+            .build();
+    final var other =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("cm-bar")
+            .withNamespace("ns")
+            .endMetadata()
+            .build();
+
+    final EventSource<ConfigMap, HasMetadata> nonCachingEventSource = mock();
+    when(nonCachingEventSource.getSecondaryResources(any())).thenReturn(Set.of(match, other));
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name"))
+        .thenReturn(nonCachingEventSource);
+
+    final var res = context.getSecondaryResource(ConfigMap.class, "es-name", "cm-foo", "ns");
+
+    assertThat(res).contains(match);
+  }
+
+  @Test
+  void getSecondaryResourceByNameAndNamespaceFallbackReturnsEmptyWhenNoMatch() {
+    final var other =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("cm-other")
+            .withNamespace("ns")
+            .endMetadata()
+            .build();
+
+    final EventSource<ConfigMap, HasMetadata> nonCachingEventSource = mock();
+    when(nonCachingEventSource.getSecondaryResources(any())).thenReturn(Set.of(other));
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name"))
+        .thenReturn(nonCachingEventSource);
+
+    assertThat(context.getSecondaryResource(ConfigMap.class, "es-name", "missing", "ns")).isEmpty();
+  }
+
+  @Test
+  void getSecondaryResourceByNameAndNamespaceRethrowsWhenNoEventSourceAndNotWorkflowManaged() {
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name"))
+        .thenThrow(new NoEventSourceForClassException(ConfigMap.class));
+
+    assertThatThrownBy(
+            () -> context.getSecondaryResource(ConfigMap.class, "es-name", "cm-foo", "ns"))
+        .isInstanceOf(NoEventSourceForClassException.class);
+  }
+
+  @Test
+  void getSecondaryResourceByNameAndNamespaceReturnsEmptyWhenNoEventSourceButWorkflowManaged() {
+    when(mockManager.getEventSourceFor(ConfigMap.class, null))
+        .thenThrow(new NoEventSourceForClassException(ConfigMap.class));
+    when(mockController.workflowContainsDependentForType(ConfigMap.class)).thenReturn(true);
+
+    final var res = context.getSecondaryResource(ConfigMap.class, null, "cm-foo", "ns");
+
+    assertThat(res).isEmpty();
+  }
+
+  @Test
+  void getSecondaryResourceByNameUsesPrimaryNamespace() {
+    final var primaryNamespace = "primary-ns";
+    final var namespacedPrimary =
+        new SecretBuilder()
+            .withNewMetadata()
+            .withName("primary")
+            .withNamespace(primaryNamespace)
+            .endMetadata()
+            .build();
+    final DefaultContext<HasMetadata> namespacedContext =
+        new DefaultContext<>(null, mockController, namespacedPrimary, false, false);
+
+    final var cm =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("cm-foo")
+            .withNamespace(primaryNamespace)
+            .endMetadata()
+            .build();
+
+    final ManagedInformerEventSource<ConfigMap, HasMetadata, ?> cachingEventSource = mock();
+    when(cachingEventSource.get(new ResourceID("cm-foo", primaryNamespace)))
+        .thenReturn(Optional.of(cm));
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name")).thenReturn(cachingEventSource);
+
+    final var res = namespacedContext.getSecondaryResource(ConfigMap.class, "es-name", "cm-foo");
+
+    assertThat(res).contains(cm);
+  }
+
+  @Test
+  void getSecondaryResourcesAsStreamByEventSourceUsesResourceCacheFastPath() {
+    final var primaryNamespace = "primary-ns";
+    final var namespacedPrimary =
+        new SecretBuilder()
+            .withNewMetadata()
+            .withName("primary")
+            .withNamespace(primaryNamespace)
+            .endMetadata()
+            .build();
+    final DefaultContext<HasMetadata> namespacedContext =
+        new DefaultContext<>(null, mockController, namespacedPrimary, false, false);
+
+    final var cm1 =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("cm-1")
+            .withNamespace(primaryNamespace)
+            .endMetadata()
+            .build();
+    final var cm2 =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("cm-2")
+            .withNamespace(primaryNamespace)
+            .endMetadata()
+            .build();
+
+    final ManagedInformerEventSource<ConfigMap, HasMetadata, ?> resourceCacheEventSource = mock();
+    when(resourceCacheEventSource.list(primaryNamespace)).thenReturn(Stream.of(cm1, cm2));
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name"))
+        .thenReturn(resourceCacheEventSource);
+
+    final var res =
+        namespacedContext.getSecondaryResourcesAsStream(ConfigMap.class, "es-name").toList();
+
+    assertThat(res).containsExactlyInAnyOrder(cm1, cm2);
+    verify(resourceCacheEventSource).list(primaryNamespace);
+  }
+
+  @Test
+  void getSecondaryResourcesAsStreamByEventSourceFastPathOnClusterScopedPrimary() {
+    // cluster-scoped primary: has metadata but no namespace set.
+    final var clusterScopedPrimary =
+        new SecretBuilder().withNewMetadata().withName("primary").endMetadata().build();
+    final DefaultContext<HasMetadata> clusterScopedContext =
+        new DefaultContext<>(null, mockController, clusterScopedPrimary, false, false);
+
+    final var cm1 = new ConfigMapBuilder().withNewMetadata().withName("cm-1").endMetadata().build();
+
+    final ManagedInformerEventSource<ConfigMap, HasMetadata, ?> resourceCacheEventSource = mock();
+    when(resourceCacheEventSource.list()).thenReturn(Stream.of(cm1));
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name"))
+        .thenReturn(resourceCacheEventSource);
+
+    final var res =
+        clusterScopedContext.getSecondaryResourcesAsStream(ConfigMap.class, "es-name").toList();
+
+    assertThat(res).containsExactly(cm1);
+    verify(resourceCacheEventSource).list();
+    verify(resourceCacheEventSource, never()).list(any(String.class));
+  }
+
+  @Test
+  void getSecondaryResourcesAsStreamByEventSourceFallsBackToGetSecondaryResources() {
+    final var cm1 =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("cm-1")
+            .withNamespace("ns")
+            .endMetadata()
+            .build();
+
+    final EventSource<ConfigMap, HasMetadata> nonCacheEventSource = mock();
+    when(nonCacheEventSource.getSecondaryResources(any())).thenReturn(Set.of(cm1));
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name")).thenReturn(nonCacheEventSource);
+
+    final var res = context.getSecondaryResourcesAsStream(ConfigMap.class, "es-name").toList();
+
+    assertThat(res).containsExactly(cm1);
+  }
+
+  @Test
+  void getSecondaryResourcesAsStreamByEventSourceRethrowsWhenNotWorkflowManaged() {
+    when(mockManager.getEventSourceFor(ConfigMap.class, "es-name"))
+        .thenThrow(new NoEventSourceForClassException(ConfigMap.class));
+
+    assertThatThrownBy(() -> context.getSecondaryResourcesAsStream(ConfigMap.class, "es-name"))
+        .isInstanceOf(NoEventSourceForClassException.class);
+  }
+
+  @Test
+  void getSecondaryResourcesAsStreamByEventSourceReturnsEmptyWhenWorkflowManaged() {
+    when(mockManager.getEventSourceFor(ConfigMap.class, null))
+        .thenThrow(new NoEventSourceForClassException(ConfigMap.class));
+    when(mockController.workflowContainsDependentForType(ConfigMap.class)).thenReturn(true);
+
+    final var res = context.getSecondaryResourcesAsStream(ConfigMap.class, null).toList();
+
     assertThat(res).isEmpty();
   }
 


### PR DESCRIPTION
Adds three typed by-name secondary-resource accessors to `Context<P>`:

- `<R extends HasMetadata> Optional<R> getSecondaryResource(Class<R>, String eventSourceName, String name, String namespace)`
- `<R extends HasMetadata> Optional<R> getSecondaryResource(Class<R>, String eventSourceName, String name)` (default; uses the primary's namespace)
- `<R extends HasMetadata> Stream<R> getSecondaryResourcesAsStream(Class<R>, String eventSourceName)`

Closes #3372 