### PR TITLE
improve: getSecondaryResourcesAsStream(expectedType,eventSourceName) does not have to be Kubernetes resources

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
@@ -194,8 +194,7 @@ public interface Context<P extends HasMetadata> {
    *     accounts for it)
    * @since 5.4.0
    */
-  <R extends HasMetadata> Stream<R> getSecondaryResourcesAsStream(
-      Class<R> expectedType, String eventSourceName);
+  <R> Stream<R> getSecondaryResourcesAsStream(Class<R> expectedType, String eventSourceName);
 
   ControllerConfiguration<P> getControllerConfiguration();
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
@@ -164,7 +164,7 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
   }
 
   @Override
-  public <R extends HasMetadata> Stream<R> getSecondaryResourcesAsStream(
+  public <R> Stream<R> getSecondaryResourcesAsStream(
       Class<R> expectedType, String eventSourceName) {
     try {
       final var eventSource =


### PR DESCRIPTION
In a previous PR we added overloaded functions for accessing resources from event sources. Some of those were limited to Kubernetes resources. I've just realized that this one should not be one of them.