### PR TITLE
improve: reconciliation counts as retry attempt only if close to retry deadline

### DIFF
--- a/docs/content/en/docs/documentation/error-handling-retries.md
+++ b/docs/content/en/docs/documentation/error-handling-retries.md
@@ -135,6 +135,9 @@ these features:
 
 2. In case an exception is thrown, a retry is initiated. However, if an event is received
    meanwhile, it will be reconciled instantly, and this execution won't count as a retry attempt.
+   If that event-triggered reconciliation also fails inside the current retry window, the
+   existing retry deadline is preserved rather than reset — the failure does not advance the
+   retry counter unless the original deadline is imminent.
 3. If the retry limit is reached (so no more automatic retry would happen), but a new event
    received, the reconciliation will still happen, but won't reset the retry, and will still be
    marked as the last attempt in the retry info. The point (1) still holds - thus successful reconciliation will reset the retry - but no retry will happen in case of an error.

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -49,6 +49,13 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
   private static final Logger log = LoggerFactory.getLogger(EventProcessor.class);
   private static final long MINIMAL_RATE_LIMIT_RESCHEDULE_DURATION = 50;
 
+  /**
+   * Threshold below which an event-driven failed reconciliation that lands inside the current retry
+   * window is allowed to consume a retry attempt (i.e. advance the retry counter). Above this
+   * threshold the existing retry deadline is preserved instead.
+   */
+  private static final long RETRY_DEADLINE_PRESERVE_THRESHOLD_MILLIS = 5_000;
+
   private volatile boolean running;
   private final ControllerConfiguration<?> controllerConfiguration;
   private final ReconciliationDispatcher<P> reconciliationDispatcher;
@@ -367,6 +374,15 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
     if (eventPresent) {
       log.debug("New events exist for resource id");
       submitReconciliationExecution(state);
+      return;
+    }
+    Optional<Duration> remaining = state.getRetry().remainingDurationUntilNextRetry();
+    if (remaining.isPresent()
+        && remaining.get().toMillis() > RETRY_DEADLINE_PRESERVE_THRESHOLD_MILLIS) {
+      log.debug(
+          "Preserving existing retry deadline; remaining: {} ms. Not consuming a retry attempt.",
+          remaining.get().toMillis());
+      retryEventSource().scheduleOnce(resourceID, remaining.get().toMillis());
       return;
     }
     Optional<Long> nextDelay = state.getRetry().nextDelay();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/GenericRetryExecution.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/GenericRetryExecution.java
@@ -15,6 +15,7 @@
  */
 package io.javaoperatorsdk.operator.processing.retry;
 
+import java.time.Duration;
 import java.util.Optional;
 
 public class GenericRetryExecution implements RetryExecution {
@@ -23,6 +24,7 @@ public class GenericRetryExecution implements RetryExecution {
 
   private int lastAttemptIndex = 0;
   private long currentInterval;
+  private Long lastNextDelayCallEpochMillis;
 
   public GenericRetryExecution(GenericRetry genericRetry) {
     this.genericRetry = genericRetry;
@@ -40,6 +42,7 @@ public class GenericRetryExecution implements RetryExecution {
       }
     }
     lastAttemptIndex++;
+    lastNextDelayCallEpochMillis = System.currentTimeMillis();
     return Optional.of(currentInterval);
   }
 
@@ -51,5 +54,17 @@ public class GenericRetryExecution implements RetryExecution {
   @Override
   public int getAttemptCount() {
     return lastAttemptIndex;
+  }
+
+  @Override
+  public Optional<Duration> remainingDurationUntilNextRetry() {
+    if (lastNextDelayCallEpochMillis == null) {
+      return Optional.empty();
+    }
+    long remaining = (lastNextDelayCallEpochMillis + currentInterval) - System.currentTimeMillis();
+    if (remaining <= 0) {
+      return Optional.empty();
+    }
+    return Optional.of(Duration.ofMillis(remaining));
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/RetryExecution.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/RetryExecution.java
@@ -36,7 +36,5 @@ public interface RetryExecution extends RetryInfo {
    * <p>Used to decide whether an event-driven failed reconciliation that lands well inside the
    * retry window should consume a retry attempt or simply be re-scheduled on the original deadline.
    */
-  default Optional<Duration> remainingDurationUntilNextRetry() {
-    return Optional.empty();
-  }
+  Optional<Duration> remainingDurationUntilNextRetry();
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/RetryExecution.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/retry/RetryExecution.java
@@ -15,6 +15,7 @@
  */
 package io.javaoperatorsdk.operator.processing.retry;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
@@ -25,4 +26,17 @@ public interface RetryExecution extends RetryInfo {
    * @return the time to wait until the next execution in milliseconds
    */
   Optional<Long> nextDelay();
+
+  /**
+   * Remaining time of the currently scheduled retry interval, i.e. the time until the previously
+   * computed retry delay would elapse. Returns an empty {@link Optional} if no retry has been
+   * scheduled yet (i.e. {@link #nextDelay()} has never been called) or if the deadline has already
+   * passed.
+   *
+   * <p>Used to decide whether an event-driven failed reconciliation that lands well inside the
+   * retry window should consume a retry attempt or simply be re-scheduled on the original deadline.
+   */
+  default Optional<Duration> remainingDurationUntilNextRetry() {
+    return Optional.empty();
+  }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventProcessorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventProcessorTest.java
@@ -466,6 +466,98 @@ class EventProcessorTest {
   }
 
   @Test
+  void preservesRetryDeadlineWhenRemainingDurationAboveThreshold() {
+    RetryExecution mockRetryExecution = mock(RetryExecution.class);
+    when(mockRetryExecution.nextDelay()).thenReturn(Optional.of(60_000L));
+    when(mockRetryExecution.remainingDurationUntilNextRetry())
+        .thenReturn(Optional.of(Duration.ofMillis(50_000)));
+    Retry retry = mock(Retry.class);
+    when(retry.initExecution()).thenReturn(mockRetryExecution);
+    eventProcessorWithRetry =
+        spy(
+            new EventProcessor(
+                controllerConfiguration(retry, LinearRateLimiter.deactivatedRateLimiter()),
+                reconciliationDispatcherMock,
+                eventSourceManagerMock,
+                metricsMock));
+    eventProcessorWithRetry.start();
+    when(eventProcessorWithRetry.retryEventSource()).thenReturn(retryTimerEventSourceMock);
+
+    TestCustomResource customResource = testCustomResource();
+    ExecutionScope executionScope =
+        new ExecutionScope(null, null, false, false).setResource(customResource);
+    PostExecutionControl postExecutionControl =
+        PostExecutionControl.exceptionDuringExecution(new RuntimeException("test"));
+
+    eventProcessorWithRetry.eventProcessingFinished(executionScope, postExecutionControl);
+
+    verify(mockRetryExecution, never()).nextDelay();
+    verify(retryTimerEventSourceMock, times(1))
+        .scheduleOnce(eq(ResourceID.fromResource(customResource)), eq(50_000L));
+  }
+
+  @Test
+  void consumesRetryAttemptWhenRemainingDurationAtOrBelowThreshold() {
+    RetryExecution mockRetryExecution = mock(RetryExecution.class);
+    when(mockRetryExecution.nextDelay()).thenReturn(Optional.of(60_000L));
+    when(mockRetryExecution.remainingDurationUntilNextRetry())
+        .thenReturn(Optional.of(Duration.ofMillis(2_000)));
+    Retry retry = mock(Retry.class);
+    when(retry.initExecution()).thenReturn(mockRetryExecution);
+    eventProcessorWithRetry =
+        spy(
+            new EventProcessor(
+                controllerConfiguration(retry, LinearRateLimiter.deactivatedRateLimiter()),
+                reconciliationDispatcherMock,
+                eventSourceManagerMock,
+                metricsMock));
+    eventProcessorWithRetry.start();
+    when(eventProcessorWithRetry.retryEventSource()).thenReturn(retryTimerEventSourceMock);
+
+    TestCustomResource customResource = testCustomResource();
+    ExecutionScope executionScope =
+        new ExecutionScope(null, null, false, false).setResource(customResource);
+    PostExecutionControl postExecutionControl =
+        PostExecutionControl.exceptionDuringExecution(new RuntimeException("test"));
+
+    eventProcessorWithRetry.eventProcessingFinished(executionScope, postExecutionControl);
+
+    verify(mockRetryExecution, times(1)).nextDelay();
+    verify(retryTimerEventSourceMock, times(1))
+        .scheduleOnce(eq(ResourceID.fromResource(customResource)), eq(60_000L));
+  }
+
+  @Test
+  void firstFailureSchedulesUsingNextDelayWhenNoRemainingDuration() {
+    RetryExecution mockRetryExecution = mock(RetryExecution.class);
+    when(mockRetryExecution.nextDelay()).thenReturn(Optional.of(60_000L));
+    when(mockRetryExecution.remainingDurationUntilNextRetry()).thenReturn(Optional.empty());
+    Retry retry = mock(Retry.class);
+    when(retry.initExecution()).thenReturn(mockRetryExecution);
+    eventProcessorWithRetry =
+        spy(
+            new EventProcessor(
+                controllerConfiguration(retry, LinearRateLimiter.deactivatedRateLimiter()),
+                reconciliationDispatcherMock,
+                eventSourceManagerMock,
+                metricsMock));
+    eventProcessorWithRetry.start();
+    when(eventProcessorWithRetry.retryEventSource()).thenReturn(retryTimerEventSourceMock);
+
+    TestCustomResource customResource = testCustomResource();
+    ExecutionScope executionScope =
+        new ExecutionScope(null, null, false, false).setResource(customResource);
+    PostExecutionControl postExecutionControl =
+        PostExecutionControl.exceptionDuringExecution(new RuntimeException("test"));
+
+    eventProcessorWithRetry.eventProcessingFinished(executionScope, postExecutionControl);
+
+    verify(mockRetryExecution, times(1)).nextDelay();
+    verify(retryTimerEventSourceMock, times(1))
+        .scheduleOnce(eq(ResourceID.fromResource(customResource)), eq(60_000L));
+  }
+
+  @Test
   void executionOfReconciliationShouldNotStartIfProcessorStopped() throws InterruptedException {
     when(reconciliationDispatcherMock.handleExecution(any()))
         .then(

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/retry/GenericRetryExecutionTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/retry/GenericRetryExecutionTest.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GenericRetryExecutionTest {
+class GenericRetryExecutionTest {
 
   @Test
-  public void noNextDelayIfMaxAttemptLimitReached() {
+  void noNextDelayIfMaxAttemptLimitReached() {
     RetryExecution retryExecution =
         GenericRetry.defaultLimitedExponentialRetry().setMaxAttempts(3).initExecution();
     Optional<Long> res = callNextDelayNTimes(retryExecution, 2);
@@ -35,7 +35,7 @@ public class GenericRetryExecutionTest {
   }
 
   @Test
-  public void canLimitMaxIntervalLength() {
+  void canLimitMaxIntervalLength() {
     RetryExecution retryExecution =
         GenericRetry.defaultLimitedExponentialRetry()
             .setInitialInterval(2000)
@@ -49,13 +49,13 @@ public class GenericRetryExecutionTest {
   }
 
   @Test
-  public void supportsNoRetry() {
+  void supportsNoRetry() {
     RetryExecution retryExecution = GenericRetry.noRetry().initExecution();
     assertThat(retryExecution.nextDelay()).isEmpty();
   }
 
   @Test
-  public void supportsIsLastExecution() {
+  void supportsIsLastExecution() {
     GenericRetryExecution execution = new GenericRetry().setMaxAttempts(2).initExecution();
     assertThat(execution.isLastAttempt()).isFalse();
 
@@ -65,7 +65,7 @@ public class GenericRetryExecutionTest {
   }
 
   @Test
-  public void returnAttemptIndex() {
+  void returnAttemptIndex() {
     RetryExecution retryExecution = GenericRetry.defaultLimitedExponentialRetry().initExecution();
 
     assertThat(retryExecution.getAttemptCount()).isEqualTo(0);
@@ -73,11 +73,59 @@ public class GenericRetryExecutionTest {
     assertThat(retryExecution.getAttemptCount()).isEqualTo(1);
   }
 
-  private RetryExecution getDefaultRetryExecution() {
-    return GenericRetry.defaultLimitedExponentialRetry().initExecution();
+  @Test
+  void remainingDurationEmptyBeforeFirstNextDelay() {
+    RetryExecution retryExecution = GenericRetry.defaultLimitedExponentialRetry().initExecution();
+
+    assertThat(retryExecution.remainingDurationUntilNextRetry()).isEmpty();
   }
 
-  public Optional<Long> callNextDelayNTimes(RetryExecution retryExecution, int n) {
+  @Test
+  void remainingDurationPresentAfterNextDelay() {
+    long interval = 60_000L;
+    RetryExecution retryExecution = new GenericRetry().setInitialInterval(interval).initExecution();
+
+    retryExecution.nextDelay();
+
+    Optional<java.time.Duration> remaining = retryExecution.remainingDurationUntilNextRetry();
+    assertThat(remaining).isPresent();
+    assertThat(remaining.get().toMillis()).isPositive().isLessThanOrEqualTo(interval);
+  }
+
+  @Test
+  void remainingDurationEmptyAfterIntervalElapsed() throws InterruptedException {
+    RetryExecution retryExecution = new GenericRetry().setInitialInterval(20).initExecution();
+
+    retryExecution.nextDelay();
+    Thread.sleep(60);
+
+    assertThat(retryExecution.remainingDurationUntilNextRetry()).isEmpty();
+  }
+
+  @Test
+  void remainingDurationReflectsUpdatedIntervalAfterSubsequentNextDelay() {
+    long initialInterval = 1000L;
+    double multiplier = 2.0;
+    RetryExecution retryExecution =
+        new GenericRetry()
+            .setInitialInterval(initialInterval)
+            .setIntervalMultiplier(multiplier)
+            .initExecution();
+
+    // first two calls keep the initial interval (multiplier only kicks in after attempt 1)
+    retryExecution.nextDelay();
+    retryExecution.nextDelay();
+    // third call doubles the interval to 2000ms
+    retryExecution.nextDelay();
+
+    Optional<java.time.Duration> remaining = retryExecution.remainingDurationUntilNextRetry();
+    assertThat(remaining).isPresent();
+    assertThat(remaining.get().toMillis())
+        .isPositive()
+        .isLessThanOrEqualTo((long) (initialInterval * multiplier));
+  }
+
+  Optional<Long> callNextDelayNTimes(RetryExecution retryExecution, int n) {
     for (int i = 0; i < n; i++) {
       retryExecution.nextDelay();
     }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/retry/RetryIntervalHonoredOnFrequentEventsIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/retry/RetryIntervalHonoredOnFrequentEventsIT.java
@@ -32,10 +32,19 @@ import static io.javaoperatorsdk.operator.baseapi.retry.RetryIT.createTestCustom
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-class RetryIntervalNotHonoredOnFrequentEventsIT {
+@Sample(
+    tldr = "Retry Interval Honored Despite Frequent Reconciliation Triggers",
+    description =
+        """
+        Verifies that with a low max attempts (3) and a high retry interval (1 minute), \
+        reconciliations triggered by external events (e.g. resource updates) during the retry \
+        window do not consume retry attempts. The retry counter should only advance when the \
+        scheduled retry deadline is approached, so the configured interval is honored.
+        """)
+class RetryIntervalHonoredOnFrequentEventsIT {
 
   private static final Logger log =
-      LoggerFactory.getLogger(RetryIntervalNotHonoredOnFrequentEventsIT.class);
+      LoggerFactory.getLogger(RetryIntervalHonoredOnFrequentEventsIT.class);
 
   public static final int MAX_RETRY_ATTEMPTS = 3;
   public static final int RETRY_INTERVAL_MILLIS = 60_000;
@@ -56,23 +65,21 @@ class RetryIntervalNotHonoredOnFrequentEventsIT {
           .build();
 
   @Test
-  void frequentEventsDuringRetryWindowExhaustRetryCounter() {
+  void frequentEventsDuringRetryWindowDoNotExhaustRetryCounter() {
     RetryTestCustomResource resource = createTestCustomResource("frequent-events");
     var created = operator.create(resource);
 
     // Wait until the initial reconciliation has been executed and failed; the retry timer is now
-    // armed for RETRY_INTERVAL_MILLIS in the future.
+    // armed for RETRY_INTERVAL_MILLIS in the future, retry counter is at 1.
     await()
         .pollInterval(Duration.ofMillis(50))
         .atMost(5, TimeUnit.SECONDS)
         .untilAsserted(
             () -> assertThat(reconciler.getNumberOfExecutions()).isGreaterThanOrEqualTo(1));
 
-    // Trigger several updates, waiting for each to result in its own reconciliation cycle. Without
-    // this spacing, multiple events would collapse into a single reconciliation and would not
-    // advance the retry counter on every update. With proper spacing, each failed reconciliation
-    // advances the retry counter — even though we are well inside the configured 1 minute
-    // interval and the retry timer hasn't fired yet.
+    // Trigger several updates spaced apart so each results in its own reconciliation cycle. Each
+    // failed reconciliation lands well inside the 1 minute retry window, so the retry counter
+    // must NOT advance — only the original retry deadline matters.
     IntStream.rangeClosed(1, NUMBER_OF_UPDATES)
         .forEach(
             i -> {
@@ -91,9 +98,10 @@ class RetryIntervalNotHonoredOnFrequentEventsIT {
                               .isGreaterThanOrEqualTo(expectedExecutions));
             });
 
-    // We reached at least MAX_RETRY_ATTEMPTS + 1 executions (initial + 3 retries) within seconds,
-    // even though the configured retry interval is 1 minute. With the interval being honored we
-    // would expect at most 1 reconciliation in this window.
-    assertThat(reconciler.getNumberOfExecutions()).isGreaterThanOrEqualTo(MAX_RETRY_ATTEMPTS + 1);
+    // Reconciliations did happen for every event (so events are not lost) but the retry counter
+    // observed inside the reconciler never went past 1: the configured 1 minute interval is
+    // honored even under a steady stream of external events.
+    assertThat(reconciler.getNumberOfExecutions()).isGreaterThanOrEqualTo(NUMBER_OF_UPDATES + 1);
+    assertThat(reconciler.getMaxObservedRetryAttempt()).isEqualTo(1);
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/retry/RetryIntervalNotHonoredOnFrequentEventsIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/retry/RetryIntervalNotHonoredOnFrequentEventsIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.retry;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.javaoperatorsdk.annotation.Sample;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
+
+import static io.javaoperatorsdk.operator.baseapi.retry.RetryIT.createTestCustomResource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class RetryIntervalNotHonoredOnFrequentEventsIT {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(RetryIntervalNotHonoredOnFrequentEventsIT.class);
+
+  public static final int MAX_RETRY_ATTEMPTS = 3;
+  public static final int RETRY_INTERVAL_MILLIS = 60_000;
+  public static final int ALL_EXECUTIONS_TO_FAIL = 99;
+  public static final int NUMBER_OF_UPDATES = 5;
+
+  RetryTestCustomReconciler reconciler = new RetryTestCustomReconciler(ALL_EXECUTIONS_TO_FAIL);
+
+  @RegisterExtension
+  LocallyRunOperatorExtension operator =
+      LocallyRunOperatorExtension.builder()
+          .withReconciler(
+              reconciler,
+              new GenericRetry()
+                  .setInitialInterval(RETRY_INTERVAL_MILLIS)
+                  .withLinearRetry()
+                  .setMaxAttempts(MAX_RETRY_ATTEMPTS))
+          .build();
+
+  @Test
+  void frequentEventsDuringRetryWindowExhaustRetryCounter() {
+    RetryTestCustomResource resource = createTestCustomResource("frequent-events");
+    var created = operator.create(resource);
+
+    // Wait until the initial reconciliation has been executed and failed; the retry timer is now
+    // armed for RETRY_INTERVAL_MILLIS in the future.
+    await()
+        .pollInterval(Duration.ofMillis(50))
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> assertThat(reconciler.getNumberOfExecutions()).isGreaterThanOrEqualTo(1));
+
+    // Trigger several updates, waiting for each to result in its own reconciliation cycle. Without
+    // this spacing, multiple events would collapse into a single reconciliation and would not
+    // advance the retry counter on every update. With proper spacing, each failed reconciliation
+    // advances the retry counter — even though we are well inside the configured 1 minute
+    // interval and the retry timer hasn't fired yet.
+    IntStream.rangeClosed(1, NUMBER_OF_UPDATES)
+        .forEach(
+            i -> {
+              log.debug("replacing resource, iteration: {}", i);
+              var latest =
+                  operator.get(RetryTestCustomResource.class, created.getMetadata().getName());
+              latest.getSpec().setValue("update-" + i);
+              operator.replace(latest);
+              int expectedExecutions = i + 1;
+              await()
+                  .pollInterval(Duration.ofMillis(50))
+                  .atMost(5, TimeUnit.SECONDS)
+                  .untilAsserted(
+                      () ->
+                          assertThat(reconciler.getNumberOfExecutions())
+                              .isGreaterThanOrEqualTo(expectedExecutions));
+            });
+
+    // We reached at least MAX_RETRY_ATTEMPTS + 1 executions (initial + 3 retries) within seconds,
+    // even though the configured retry interval is 1 minute. With the interval being honored we
+    // would expect at most 1 reconciliation in this window.
+    assertThat(reconciler.getNumberOfExecutions()).isGreaterThanOrEqualTo(MAX_RETRY_ATTEMPTS + 1);
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/retry/RetryTestCustomReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/retry/RetryTestCustomReconciler.java
@@ -32,6 +32,7 @@ public class RetryTestCustomReconciler
 
   private static final Logger log = LoggerFactory.getLogger(RetryTestCustomReconciler.class);
   private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
+  private final AtomicInteger maxObservedRetryAttempt = new AtomicInteger(0);
 
   private final AtomicInteger numberOfExecutionFails;
 
@@ -43,6 +44,12 @@ public class RetryTestCustomReconciler
   public UpdateControl<RetryTestCustomResource> reconcile(
       RetryTestCustomResource resource, Context<RetryTestCustomResource> context) {
     numberOfExecutions.addAndGet(1);
+    context
+        .getRetryInfo()
+        .ifPresent(
+            info ->
+                maxObservedRetryAttempt.updateAndGet(
+                    prev -> Math.max(prev, info.getAttemptCount())));
 
     log.info("Value: " + resource.getSpec().getValue());
 
@@ -69,5 +76,9 @@ public class RetryTestCustomReconciler
 
   public int getNumberOfExecutions() {
     return numberOfExecutions.get();
+  }
+
+  public int getMaxObservedRetryAttempt() {
+    return maxObservedRetryAttempt.get();
   }
 }


### PR DESCRIPTION
Currently there is already a retry happening, and we receive an event that triggers the reconciliation counts as a retry. But this way we can fairly easily exhaust retries. So algorithm should is changed a reconciliation counts as a retry only if it is close enough to a scheduled retry.

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
