### PR TITLE
improve: clarify EventProcessor logging and contract for events received before start

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -116,8 +116,8 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
    * io.javaoperatorsdk.operator.processing.event.source.EventSource} and either dispatches it for
    * immediate processing or, if this processor has not been {@link #start() started} yet, marks it
    * in the resource state so it can be replayed by {@link #handleAlreadyMarkedEvents()} once the
-   * processor starts. Events received during the start-up window between event source readiness
-   * and processor start are therefore deferred rather than dropped.
+   * processor starts. Events received during the start-up window between event source readiness and
+   * processor start are therefore deferred rather than dropped.
    */
   @Override
   public synchronized void handleEvent(Event event) {
@@ -142,8 +142,7 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
           cleanupForDeletedEvent(state.getId());
         }
         // events are received and marked, but will be processed when started, see start() method.
-        log.debug(
-            "Deferring event: {} until the event processor starts", event);
+        log.debug("Deferring event: {} until the event processor starts", event);
         return;
       }
       handleMarkedEventForResource(state);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -111,6 +111,14 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
             .orElseGet(HashMap::new);
   }
 
+  /**
+   * Receives an {@link Event} from a registered {@link
+   * io.javaoperatorsdk.operator.processing.event.source.EventSource} and either dispatches it for
+   * immediate processing or, if this processor has not been {@link #start() started} yet, marks it
+   * in the resource state so it can be replayed by {@link #handleAlreadyMarkedEvents()} once the
+   * processor starts. Events received during the start-up window between event source readiness
+   * and processor start are therefore deferred rather than dropped.
+   */
   @Override
   public synchronized void handleEvent(Event event) {
     try {
@@ -134,7 +142,8 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
           cleanupForDeletedEvent(state.getId());
         }
         // events are received and marked, but will be processed when started, see start() method.
-        log.debug("Skipping event: {} because the event processor is not started", event);
+        log.debug(
+            "Deferring event: {} until the event processor starts", event);
         return;
       }
       handleMarkedEventForResource(state);


### PR DESCRIPTION
## Summary

When the SDK starts up, there is a short window (observed at ~140 ms on Flink Kubernetes Operator startup) between when `EventSourceManager` starts the informers and when `EventProcessor.start()` is actually called. During that window, the initial informer LIST emits ADDED events for every existing resource, and `EventProcessor.handleEvent(...)` receives them while `running == false`.

The events are not lost. `handleEvent` calls `resourceStateManager.getOrCreateOnResourceEvent(...)`, records the metric, and then calls `handleEventMarking(event, state)` before checking `running`. When `EventProcessor.start()` is eventually invoked, it sets `running = true` and calls `handleAlreadyMarkedEvents()`, which replays every state with `eventPresent()`. Delete events are also short-circuited to `cleanupForDeletedEvent(...)` even when not running.

The problem is that the log message in this branch is alarming and reads exactly like dropped work:

```
Skipping event: ResourceEvent{...} because the event processor is not started
```

…and there is no JavaDoc on `handleEvent` explaining the marking-then-replay contract, so the only way to confirm "events are not lost" is to read the code.

This PR clarifies both:

1. **Log message reworded.** From *"Skipping event: {} because the event processor is not started"* to *"Deferring event: {} until the event processor starts"*. Same log level, same information, no behavior change. Just stops users (and downstream operator authors debugging startup) from believing the SDK is silently discarding events.
2. **JavaDoc added on `handleEvent`.** One short paragraph that documents the deferral-and-replay contract and points at `#start()` and `#handleAlreadyMarkedEvents()` so future readers don't have to reverse-engineer the flow.

No behavior change. Strictly an observability + documentation improvement.

## Why this came up

While debugging an unrelated issue on Flink Kubernetes Operator, I noticed the following sequence in DEBUG logs at startup:

```
EventSourceManager   [DEBUG] Starting event source ControllerResourceEventSource ...
InformerWrapper      [DEBUG] Starting informer for namespace: JOSDK_ALL_NAMESPACES ...
EventProcessor       [DEBUG] Received event: ResourceEvent{action=ADDED, ...}
EventProcessor       [DEBUG] Skipping event: ResourceEvent{...} because the event processor is not started
... (repeats for many resources) ...
EventProcessor       [DEBUG] Starting event processor: ...
```

The "Skipping event ... not started" message is misleading as it looks like silently dropped initial state. The code is correct (the events are marked and replayed via `handleAlreadyMarkedEvents`), but the log line and the missing JavaDoc made it hard to tell from operator logs alone.
