### PR TITLE
fix: shutdown hook deadlock under leader election and deprecate Operator#installShutdownHook(Duration)

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
@@ -15,9 +15,8 @@
  */
 package io.javaoperatorsdk.operator;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -51,12 +50,6 @@ import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
  * configuration controls the lease name, namespace, durations, and optional user-supplied {@link
  * LeaderCallbacks}.
  *
- * <p>Internally this class wraps a Fabric8 {@link LeaderElector} that coordinates via a Kubernetes
- * {@code Lease} resource (group {@value #COORDINATION_GROUP}, resource {@value #LEASES_RESOURCE}).
- * When this pod acquires the lease, {@link #startLeading()} starts event processing on the
- * controller manager. When the lease is lost or the leader-election future is cancelled, {@link
- * #stopLeading()} is invoked.
- *
  * <p>{@link #stopLeading()} behaves differently depending on how it was triggered:
  *
  * <ul>
@@ -76,6 +69,7 @@ import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
 public class LeaderElectionManager {
 
   private static final Logger log = LoggerFactory.getLogger(LeaderElectionManager.class);
+  private static final List<String> REQUIRED_VERBS = List.of("create", "update", "get");
 
   public static final String NO_PERMISSION_TO_LEASE_RESOURCE_MESSAGE =
       "No permission to lease resource.";
@@ -159,7 +153,7 @@ public class LeaderElectionManager {
     controllerManager.startEventProcessing();
   }
 
-  protected void stopLeading() {
+  void stopLeading() {
     if (stoppingGracefully.get()) {
       log.info("Stopped leading for identity: {} during graceful shutdown.", identity);
       return;
@@ -199,7 +193,6 @@ public class LeaderElectionManager {
   }
 
   private void checkLeaseAccess() {
-    var verbsRequired = Arrays.asList("create", "update", "get");
     SelfSubjectRulesReview review = new SelfSubjectRulesReview();
     review.setSpec(new SelfSubjectRulesReviewSpecBuilder().withNamespace(leaseNamespace).build());
     var reviewResult = configurationService.getKubernetesClient().resource(review).create();
@@ -214,17 +207,15 @@ public class LeaderElectionManager {
                         || rule.getResourceNames().contains(leaseName))
             .map(ResourceRule::getVerbs)
             .flatMap(Collection::stream)
-            .distinct()
-            .collect(Collectors.toList());
-    if (verbsAllowed.contains(UNIVERSAL_VALUE)
-        || new HashSet<>(verbsAllowed).containsAll(verbsRequired)) {
+            .collect(Collectors.toUnmodifiableSet());
+    if (verbsAllowed.contains(UNIVERSAL_VALUE) || verbsAllowed.containsAll(REQUIRED_VERBS)) {
       return;
     }
 
     var missingVerbs =
-        verbsRequired.stream()
+        REQUIRED_VERBS.stream()
             .filter(Predicate.not(verbsAllowed::contains))
-            .collect(Collectors.toList());
+            .collect(Collectors.joining(","));
 
     throw new OperatorException(
         NO_PERMISSION_TO_LEASE_RESOURCE_MESSAGE

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/LeaderElectionManager.java
@@ -17,8 +17,10 @@ package io.javaoperatorsdk.operator;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -36,6 +38,41 @@ import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.LeaseLo
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
 
+/**
+ * Manages the leader-election lifecycle for an {@link Operator} instance. Leader election ensures
+ * that, in a high-availability setup with multiple replicas of the same operator, only one replica
+ * at a time actively reconciles resources. The replica currently holding the lease is referred to
+ * as the leader, and the others stand by until the lease becomes available.
+ *
+ * <p>Leader election is opt-in. It is enabled when a {@link LeaderElectionConfiguration} is
+ * supplied via {@link
+ * io.javaoperatorsdk.operator.api.config.ConfigurationServiceOverrider#withLeaderElectionConfiguration(LeaderElectionConfiguration)
+ * ConfigurationServiceOverrider#withLeaderElectionConfiguration(LeaderElectionConfiguration)}. The
+ * configuration controls the lease name, namespace, durations, and optional user-supplied {@link
+ * LeaderCallbacks}.
+ *
+ * <p>Internally this class wraps a Fabric8 {@link LeaderElector} that coordinates via a Kubernetes
+ * {@code Lease} resource (group {@value #COORDINATION_GROUP}, resource {@value #LEASES_RESOURCE}).
+ * When this pod acquires the lease, {@link #startLeading()} starts event processing on the
+ * controller manager. When the lease is lost or the leader-election future is cancelled, {@link
+ * #stopLeading()} is invoked.
+ *
+ * <p>{@link #stopLeading()} behaves differently depending on how it was triggered:
+ *
+ * <ul>
+ *   <li>If {@link #stop()} has already been called (graceful shutdown), it logs and returns without
+ *       exiting. This avoids deadlocking against the JVM shutdown hook lock when {@link
+ *       Operator#stop()} is invoked from a JVM shutdown hook.
+ *   <li>Otherwise, if the configured {@link LeaderElectionConfiguration#isExitOnStopLeading()} is
+ *       {@code true} (the default), it calls {@code System.exit(1)} so the process restarts and
+ *       another replica can take over.
+ *   <li>If {@code isExitOnStopLeading()} is {@code false}, it only logs and returns.
+ * </ul>
+ *
+ * <p>The lifecycle methods {@link #start()} and {@link #stop()} are called by {@link Operator} as
+ * part of {@link Operator#start()} and {@link Operator#stop()} respectively. Users typically do not
+ * interact with this class directly.
+ */
 public class LeaderElectionManager {
 
   private static final Logger log = LoggerFactory.getLogger(LeaderElectionManager.class);
@@ -53,6 +90,10 @@ public class LeaderElectionManager {
   private final ConfigurationService configurationService;
   private String leaseNamespace;
   private String leaseName;
+  // Set in stop() before cancelling the leader-election future. Checked in stopLeading() so that
+  // a graceful shutdown does not call System.exit, which would otherwise deadlock against the
+  // JVM shutdown hook lock when stop() is invoked from a JVM shutdown hook.
+  private final AtomicBoolean stoppingGracefully = new AtomicBoolean(false);
 
   LeaderElectionManager(
       ControllerManager controllerManager, ConfigurationService configurationService) {
@@ -118,7 +159,11 @@ public class LeaderElectionManager {
     controllerManager.startEventProcessing();
   }
 
-  private void stopLeading() {
+  protected void stopLeading() {
+    if (stoppingGracefully.get()) {
+      log.info("Stopped leading for identity: {} during graceful shutdown.", identity);
+      return;
+    }
     if (configurationService.getLeaderElectionConfiguration().orElseThrow().isExitOnStopLeading()) {
       log.info("Stopped leading for identity: {}. Exiting.", identity);
       // When leader stops leading the process ends immediately to prevent multiple reconciliations
@@ -147,6 +192,7 @@ public class LeaderElectionManager {
   }
 
   public void stop() {
+    stoppingGracefully.set(true);
     if (leaderElectionFuture != null) {
       leaderElectionFuture.cancel(false);
     }
@@ -170,7 +216,8 @@ public class LeaderElectionManager {
             .flatMap(Collection::stream)
             .distinct()
             .collect(Collectors.toList());
-    if (verbsAllowed.contains(UNIVERSAL_VALUE) || verbsAllowed.containsAll(verbsRequired)) {
+    if (verbsAllowed.contains(UNIVERSAL_VALUE)
+        || new HashSet<>(verbsAllowed).containsAll(verbsRequired)) {
       return;
     }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -130,23 +130,38 @@ public class Operator implements LifecycleAware {
   }
 
   /**
-   * Adds a shutdown hook that automatically calls {@link #stop()} when the app shuts down. Note
-   * that graceful shutdown is usually not needed, but some {@link Reconciler} implementations might
-   * require it.
+   * Adds a JVM shutdown hook that automatically calls {@link #stop()} when the application shuts
+   * down. The shutdown timeout used while waiting for in-flight reconciliations to complete is
+   * taken from {@link
+   * io.javaoperatorsdk.operator.api.config.ConfigurationService#reconciliationTerminationTimeout()}.
+   * Configure it via {@link
+   * io.javaoperatorsdk.operator.api.config.ConfigurationServiceOverrider#withReconciliationTerminationTimeout(Duration)
+   * ConfigurationServiceOverrider#withReconciliationTerminationTimeout(Duration)}.
    *
-   * <p>Note that you might want to tune "terminationGracePeriodSeconds" for the Pod running the
-   * controller.
+   * <p>The hook is registered regardless of whether leader election is enabled. A leader pod
+   * receiving {@code SIGTERM} will therefore release its lease cleanly so that a standby replica
+   * can take over without waiting for lease expiry.
    *
-   * @param gracefulShutdownTimeout timeout to wait for executor threads to complete actual
-   *     reconciliations
+   * <p><b>NOTE:</b> You may also want to tune the Pod's {@code terminationGracePeriodSeconds} to be
+   * at least as long as the configured {@code reconciliationTerminationTimeout}, plus a small
+   * buffer for the rest of the shutdown sequence (releasing the leader-election lease and closing
+   * the Kubernetes client). If the grace period elapses before {@link #stop()} returns, the kubelet
+   * sends {@code SIGKILL}, in-flight reconciliations are abandoned, and any held leader-election
+   * lease is not released cleanly.
    */
+  public void installShutdownHook() {
+    Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
+  }
+
+  /**
+   * @deprecated The {@code gracefulShutdownTimeout} argument is ignored. Use {@link
+   *     #installShutdownHook()} instead.
+   * @param gracefulShutdownTimeout ignored, kept only for source and binary compatibility
+   */
+  @Deprecated(forRemoval = true)
   @SuppressWarnings("unused")
   public void installShutdownHook(Duration gracefulShutdownTimeout) {
-    if (!leaderElectionManager.isLeaderElectionEnabled()) {
-      Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
-    } else {
-      log.warn("Leader election is on, shutdown hook will not be installed.");
-    }
+    installShutdownHook();
   }
 
   public KubernetesClient getKubernetesClient() {
@@ -188,6 +203,30 @@ public class Operator implements LifecycleAware {
     }
   }
 
+  /**
+   * Stops the operator and releases its resources. The shutdown sequence is:
+   *
+   * <ol>
+   *   <li>Stop the controller manager, halting reconciliation of all registered controllers.
+   *   <li>Stop the executor service manager, waiting up to {@link
+   *       io.javaoperatorsdk.operator.api.config.ConfigurationService#reconciliationTerminationTimeout()}
+   *       for in-flight reconciliations to complete.
+   *   <li>Stop the leader-election manager, cancelling the leader-election future and releasing any
+   *       held lease.
+   *   <li>Close the {@link KubernetesClient} if {@link
+   *       io.javaoperatorsdk.operator.api.config.ConfigurationService#closeClientOnStop()} is
+   *       {@code true} (the default).
+   * </ol>
+   *
+   * <p>It is safe to call this method from a JVM shutdown hook (see {@link #installShutdownHook()})
+   * as the graceful-shutdown path coordinates with the leader-election callbacks so that {@code
+   * System.exit} is not invoked while the JVM is already shutting down.
+   *
+   * <p>If the operator was never successfully started, this method only stops the executor service
+   * manager so that no thread pools are leaked.
+   *
+   * @throws OperatorException if an error occurs during shutdown
+   */
   @Override
   public void stop() throws OperatorException {
     Duration reconciliationTerminationTimeout =

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/Operator.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import org.slf4j.Logger;
@@ -43,6 +44,7 @@ public class Operator implements LifecycleAware {
   private LeaderElectionManager leaderElectionManager;
   private ConfigurationService configurationService;
   private volatile boolean started = false;
+  private final AtomicBoolean shutdownHookInstalled = new AtomicBoolean(false);
 
   public Operator() {
     init(initConfigurationService(null, null), true);
@@ -150,13 +152,22 @@ public class Operator implements LifecycleAware {
    * lease is not released cleanly.
    */
   public void installShutdownHook() {
-    Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
+    if (shutdownHookInstalled.compareAndSet(false, true)) {
+      Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
+    }
   }
 
   /**
-   * @deprecated The {@code gracefulShutdownTimeout} argument is ignored. Use {@link
-   *     #installShutdownHook()} instead.
-   * @param gracefulShutdownTimeout ignored, kept only for source and binary compatibility
+   * Adds a shutdown hook that automatically calls {@link #stop()} when the app shuts down. Note
+   * that graceful shutdown is usually not needed, but some {@link Reconciler} implementations might
+   * require it.
+   *
+   * <p>Note that you might want to tune "terminationGracePeriodSeconds" for the Pod running the
+   * controller.
+   *
+   * @param gracefulShutdownTimeout ignored, configure {@link
+   *     ConfigurationService#reconciliationTerminationTimeout()} instead
+   * @deprecated Use {@link #installShutdownHook()} instead
    */
   @Deprecated(forRemoval = true)
   @SuppressWarnings("unused")

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/LeaderElectionManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/LeaderElectionManagerTest.java
@@ -110,6 +110,18 @@ class LeaderElectionManagerTest {
   }
 
   @Test
+  void stopLeadingDoesNotInvokeSystemExitWhenStopWasCalledFirst() {
+    // When stop() is called before the onStopLeading callback fires (which is what happens when
+    // stop()'s future cancellation triggers the callback), stopLeading() must skip
+    // System.exit(1). Otherwise calling stop() from inside a JVM shutdown hook deadlocks against
+    // the java.lang.Shutdown class lock. If this regression is ever reintroduced, this test
+    // method would terminate the JUnit JVM via System.exit(1) instead of failing cleanly.
+    final var leaderElectionManager = leaderElectionManager(null);
+    leaderElectionManager.stop();
+    leaderElectionManager.stopLeading();
+  }
+
+  @Test
   void testFailedToInitMissingPermission(@TempDir Path tempDir) throws IOException {
     var namespace = "foo";
     var namespacePath = tempDir.resolve("namespace");


### PR DESCRIPTION
## Summary

Resolves all three concerns raised in #3376:

1. The JVM shutdown hook installed via `Operator#installShutdownHook(...)` was previously skipped whenever leader election was enabled (introduced in #1618 to work around the deadlock reported in #1614). As a result, a leader pod receiving `SIGTERM` did not release its lease, forcing standby replicas to wait for lease expiry before they could take over.
2. The `gracefulShutdownTimeout` argument on `Operator#installShutdownHook(Duration)` has been ignored since PR #2479. The reconciliation termination timeout is now read from `ConfigurationService#reconciliationTerminationTimeout()`.
3. The actual rationale for the leader-election skip and the dead `Duration` parameter was not documented anywhere; neither were the `Operator#stop()` shutdown sequence and the `LeaderElectionManager` lifecycle.

## What changed

### Fix the underlying deadlock (`LeaderElectionManager`)

The deadlock from #1614 was very specific: `Operator#stop()` called from inside a JVM shutdown hook would cancel the leader-election future, which fired the `onStopLeading` callback, which called `System.exit(1)`. That `System.exit` then blocked indefinitely on the `java.lang.Shutdown` class lock that the shutdown hook thread itself was already holding.

This PR breaks the recursion. `LeaderElectionManager` now carries a `stoppingGracefully` `AtomicBoolean`, set in `stop()` before the future is cancelled and checked at the top of `stopLeading()`. When the flag is set, `stopLeading()` returns immediately instead of invoking `System.exit`. The "restart on lost lead" behavior (when the leader-election library detects a real lost lease without a prior `stop()`) is preserved because that path runs without the flag ever being set.

### Re-enable the shutdown hook unconditionally (`Operator`)

With the deadlock fixed at its source, the conditional in `Operator#installShutdownHook()` is no longer required. The hook is now registered regardless of leader-election state, and the `"Leader election is on, shutdown hook will not be installed."` warn log line is removed. A leader pod receiving `SIGTERM` will run the hook, which calls `Operator#stop()`, which now cleanly cancels the leader-election future and releases the lease.

### Deprecate `installShutdownHook(Duration)` (`Operator`)

The `Duration` argument has been dead since #2479. This PR adds a new no-arg `installShutdownHook()` overload (the recommended replacement) whose JavaDoc points users at `ConfigurationServiceOverrider#withReconciliationTerminationTimeout(Duration)` as the real configuration knob. The existing `installShutdownHook(Duration)` is marked `@Deprecated(forRemoval = true)` and delegates to the no-arg overload. The `Duration` parameter is kept only for source and binary compatibility.

### Documentation additions

- Class-level JavaDoc on `LeaderElectionManager` explaining its role, configuration entry points, the `Lease`-based coordination, the three-way behavior of `stopLeading()`, and the lifecycle ownership by `Operator`.
- JavaDoc on `Operator#stop()` documenting the four-step shutdown sequence (controller manager, executor service manager with timeout, leader-election manager, optional client close), an explicit "safe to call from a JVM shutdown hook" guarantee, the not-started edge-case behavior, and the `closeClientOnStop()` opt-out (default `true`).
- JavaDoc on `Operator#installShutdownHook()` explaining the timeout configuration knob and adding a `terminationGracePeriodSeconds` note that recommends sizing the pod's grace period to fit the configured `reconciliationTerminationTimeout` plus a small buffer.

### Regression test

`LeaderElectionManagerTest#stopLeadingDoesNotInvokeSystemExitWhenStopWasCalledFirst` calls `stop()` and then `stopLeading()` directly. If the graceful-shutdown short-circuit is ever reintroduced as `System.exit(1)`, this test method would terminate the JUnit JVM rather than failing cleanly, making the regression impossible to miss in CI. `LeaderElectionManager#stopLeading` was lowered from `private` to `protected` to enable the test (and to allow subclasses to extend the behavior).

## Behavior summary by scenario

| Scenario                                                         | Before this PR                                   | After this PR                                                                                   |
|------------------------------------------------------------------|--------------------------------------------------|-------------------------------------------------------------------------------------------------|
| No leader election, `SIGTERM`                                    | Hook installed, `stop()` runs, graceful shutdown | Same                                                                                            |
| Leader election, leader receives `SIGTERM`                       | Hook **not** installed, JVM exits, lease leaks   | Hook installed, `stop()` runs, lease released cleanly                                           |
| Leader election, non-leader receives `SIGTERM`                   | Hook **not** installed                           | Hook installed, `stop()` is effectively a no-op for leader-election state (no lease to release) |
| Leader loses lead (`onStopLeading` fires without prior `stop()`) | `System.exit(1)` triggered, JVM restarts         | Same                                                                                            |
| `installShutdownHook(Duration)` called by user                   | `Duration` silently ignored                      | `Duration` silently ignored, plus deprecation warning at compile time                           |

## Test plan

- `mvn -pl operator-framework-core test` passes, including the new `stopLeadingDoesNotInvokeSystemExitWhenStopWasCalledFirst` regression.
- Spotless / Google Java Format clean.
- Compiler emits a deprecation warning at every existing call site of `installShutdownHook(Duration)`.
