### PR TITLE
test: reset ExternalIDGenServiceMock between tests to fix flaky external-state ITs

### DIFF
--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateTestBase.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateTestBase.java
@@ -15,6 +15,7 @@
  */
 package io.javaoperatorsdk.operator.dependent.externalstate;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -34,6 +35,11 @@ public abstract class ExternalStateTestBase {
   public static final String UPDATED_DATA = "updatedData";
 
   private final ExternalIDGenServiceMock externalService = ExternalIDGenServiceMock.getInstance();
+
+  @BeforeEach
+  void resetExternalService() {
+    externalService.reset();
+  }
 
   @Test
   public void reconcilesResourceWithPersistentState() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateTestBase.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateTestBase.java
@@ -15,18 +15,20 @@
  */
 package io.javaoperatorsdk.operator.dependent.externalstate;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.javaoperatorsdk.operator.support.ExternalIDGenServiceMock;
+import io.javaoperatorsdk.operator.support.ExternalServiceResetExtension;
 
 import static io.javaoperatorsdk.operator.dependent.externalstate.ExternalStateReconciler.ID_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+@ExtendWith(ExternalServiceResetExtension.class)
 public abstract class ExternalStateTestBase {
 
   private static final String TEST_RESOURCE_NAME = "test1";
@@ -35,11 +37,6 @@ public abstract class ExternalStateTestBase {
   public static final String UPDATED_DATA = "updatedData";
 
   private final ExternalIDGenServiceMock externalService = ExternalIDGenServiceMock.getInstance();
-
-  @BeforeEach
-  void resetExternalService() {
-    externalService.reset();
-  }
 
   @Test
   public void reconcilesResourceWithPersistentState() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/externalstatebulkdependent/ExternalStateBulkIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/externalstatebulkdependent/ExternalStateBulkIT.java
@@ -17,6 +17,7 @@ package io.javaoperatorsdk.operator.dependent.externalstate.externalstatebulkdep
 
 import java.time.Duration;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -48,6 +49,11 @@ class ExternalStateBulkIT {
   public static final int DECREASED_BULK_SIZE = 2;
 
   private final ExternalIDGenServiceMock externalService = ExternalIDGenServiceMock.getInstance();
+
+  @BeforeEach
+  void resetExternalService() {
+    externalService.reset();
+  }
 
   @RegisterExtension
   LocallyRunOperatorExtension operator =

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/externalstatebulkdependent/ExternalStateBulkIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/externalstatebulkdependent/ExternalStateBulkIT.java
@@ -17,14 +17,15 @@ package io.javaoperatorsdk.operator.dependent.externalstate.externalstatebulkdep
 
 import java.time.Duration;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.javaoperatorsdk.annotation.Sample;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.javaoperatorsdk.operator.support.ExternalIDGenServiceMock;
+import io.javaoperatorsdk.operator.support.ExternalServiceResetExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -38,6 +39,7 @@ import static org.awaitility.Awaitility.await;
         allowing operators to track and reconcile a variable number of external resources with \
         persistent state that survives operator restarts.
         """)
+@ExtendWith(ExternalServiceResetExtension.class)
 class ExternalStateBulkIT {
 
   private static final String TEST_RESOURCE_NAME = "test1";
@@ -49,11 +51,6 @@ class ExternalStateBulkIT {
   public static final int DECREASED_BULK_SIZE = 2;
 
   private final ExternalIDGenServiceMock externalService = ExternalIDGenServiceMock.getInstance();
-
-  @BeforeEach
-  void resetExternalService() {
-    externalService.reset();
-  }
 
   @RegisterExtension
   LocallyRunOperatorExtension operator =

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/support/ExternalIDGenServiceMock.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/support/ExternalIDGenServiceMock.java
@@ -50,6 +50,14 @@ public class ExternalIDGenServiceMock {
     return new ArrayList<>(resourceMap.values());
   }
 
+  /**
+   * Clears the internal state. Intended to be called between tests so that state from one test
+   * does not leak into the next via this JVM-lifetime singleton.
+   */
+  public void reset() {
+    resourceMap.clear();
+  }
+
   public static ExternalIDGenServiceMock getInstance() {
     return serviceMock;
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/support/ExternalIDGenServiceMock.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/support/ExternalIDGenServiceMock.java
@@ -51,8 +51,8 @@ public class ExternalIDGenServiceMock {
   }
 
   /**
-   * Clears the internal state. Intended to be called between tests so that state from one test
-   * does not leak into the next via this JVM-lifetime singleton.
+   * Clears the internal state. Intended to be called between tests so that state from one test does
+   * not leak into the next via this JVM-lifetime singleton.
    */
   public void reset() {
     resourceMap.clear();

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/support/ExternalServiceResetExtension.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/support/ExternalServiceResetExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.support;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Resets the {@link ExternalIDGenServiceMock} singleton before each test method so that state from
+ * one test does not leak into the next. Apply via
+ * {@code @ExtendWith(ExternalServiceResetExtension.class)}.
+ */
+public class ExternalServiceResetExtension implements BeforeEachCallback {
+
+  @Override
+  public void beforeEach(@NonNull ExtensionContext context) {
+    ExternalIDGenServiceMock.getInstance().reset();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes an intermittent CI failure in three integration tests (an example can be found here: https://github.com/operator-framework/java-operator-sdk/actions/runs/26563951370/job/78253684721?pr=3383):

- `ExternalStateIT.reconcilesResourceWithPersistentState`
- `ExternalStateDependentIT.reconcilesResourceWithPersistentState` (extends `ExternalStateTestBase`)
- `ExternalStateBulkIT.reconcilesResourceWithPersistentState`

Symptoms in CI:

```
Expected size: 1 but was: 2 in:
[io.javaoperatorsdk.operator.support.ExternalResource@4f234290,
 io.javaoperatorsdk.operator.support.ExternalResource@3370ff56] within 10 seconds.
```

The same `ExternalResource@3370ff56` instance hash showed up in all three failures, which is the giveaway: an `ExternalResource` object was outliving the test that created it.

## Root cause

`operator-framework/src/test/java/io/javaoperatorsdk/operator/support/ExternalIDGenServiceMock.java` is a JVM-lifetime singleton with a mutable `ConcurrentHashMap` field:

```java
public class ExternalIDGenServiceMock {
  private static final ExternalIDGenServiceMock serviceMock = new ExternalIDGenServiceMock();
  private final Map<String, ExternalResource> resourceMap = new ConcurrentHashMap<>();
  // ...
  public static ExternalIDGenServiceMock getInstance() { return serviceMock; }
}
```

Each external-state test creates resources through `getInstance().create(...)` (entered into `resourceMap`) and expects the reconciler's cleanup path to remove them after the custom resource is deleted. Cleanup is asynchronous, so when the next test runs there is a race window in which the previous test's `ExternalResource` is still in the map. The next test creates its own resource, sees two entries, and `Awaitility` times out after 10 s.

## Fix

Three small, test-only changes:

1. Add a `reset()` method to `ExternalIDGenServiceMock` that clears the internal map.
2. Call it from a `@BeforeEach` in `ExternalStateTestBase` (covers both `ExternalStateIT` and `ExternalStateDependentIT`).
3. Call it from a `@BeforeEach` in `ExternalStateBulkIT` (which does not extend the base).

## Concurrency note

JOSDK does not enable JUnit 5 parallel execution (no `junit-platform.properties`, no `junit.jupiter.execution.parallel.*` properties in any `pom.xml`). The flake addressed here is a sequential test-ordering issue, not a parallel-execution one, and the `BeforeEachCallback` is sufficient given that constraint. If parallel execution is ever enabled, the singleton would need to be replaced by per-test instances rather than relying on `reset()`.

## Test plan

- `mvn -pl operator-framework verify -Dit.test=ExternalStateIT,ExternalStateDependentIT,ExternalStateBulkIT` passes locally on a clean checkout.
- No other tests use `ExternalIDGenServiceMock`.
