### PR TITLE
improve: extend SecondaryToPrimaryMapper so it also gets the old resource

### DIFF
--- a/docs/content/en/docs/documentation/eventing.md
+++ b/docs/content/en/docs/documentation/eventing.md
@@ -139,6 +139,25 @@ rare corner cases. Returning an empty set means that the mapper considered the s
 resource event as irrelevant and the SDK will thus not trigger a reconciliation of the primary
 resource in that situation.
 
+`SecondaryToPrimaryMapper` exposes two methods:
+
+- `toPrimaryResourceIDs(R resource)` — the original mapper. Implementing it is sufficient for
+  the vast majority of use cases.
+- `toPrimaryResourceIDs(R newResource, R oldResource)` — a variant that is the one actually
+  invoked by the SDK on every secondary event. Its default implementation delegates to the
+  single-argument method, so existing mappers keep working unchanged.
+
+Override the two-argument variant only in edge cases where the set of primary resources to
+reconcile depends on what changed between the previous and the new version of the secondary
+resource (e.g. a reference that moved from one primary to another, where both primaries need
+to be reconciled). **Use it with caution:** `oldResource` is sourced from the informer cache and
+is only populated for genuine update events observed while the controller is already running.
+On controller startup the cache is empty, so the initial events received for resources that
+already exist in the cluster are delivered as adds with `oldResource == null` — even if those
+resources had been updated before the operator came up. `oldResource` is also `null` for delete
+events and for events triggered through the primary-to-secondary index. Implementations must
+therefore handle a `null` `oldResource` gracefully.
+
 Adding a `SecondaryToPrimaryMapper` is typically sufficient when there is a one-to-many relationship
 between primary and secondary resources. The secondary resources can be mapped to its primary
 owner, and this is enough information to also get these secondary resources from the `Context`

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/SecondaryToPrimaryMapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/SecondaryToPrimaryMapper.java
@@ -26,9 +26,48 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
  */
 @FunctionalInterface
 public interface SecondaryToPrimaryMapper<R> {
+
   /**
-   * @param resource - secondary
-   * @return set of primary resource IDs
+   * Maps a secondary resource to the set of primary resources that should be reconciled in
+   * response. Implementing this single-argument form is sufficient for the vast majority of use
+   * cases — prefer it unless you specifically need access to the previous version of the
+   * secondary resource (see {@link #toPrimaryResourceIDs(Object, Object)}).
+   *
+   * @param resource the secondary resource for which an event was received
+   * @return set of primary resource IDs to enqueue for reconciliation; an empty set means the
+   *     event is irrelevant and no reconciliation is triggered
    */
   Set<ResourceID> toPrimaryResourceIDs(R resource);
+
+  /**
+   * Variant invoked by the framework for every secondary resource event, providing both the new and
+   * the previous version of the resource (when available). The default implementation simply
+   * delegates to {@link #toPrimaryResourceIDs(Object)} and ignores {@code oldResource}, so existing
+   * mappers keep working unchanged.
+   *
+   * <p>Override this method only for edge cases where the set of primary resources to reconcile
+   * depends on what changed between the old and the new version of the secondary resource (for
+   * example, when a reference held by the secondary resource has moved from one primary to another
+   * and both primaries need to be reconciled).
+   *
+   * <p><strong>Use with caution.</strong> {@code oldResource} is sourced from the informer cache
+   * and is therefore only populated for genuine update events observed while the controller is
+   * already running. In particular, when the controller starts up, the cache is empty and the
+   * initial events received for resources that already existed in the cluster are delivered as adds
+   * with {@code oldResource == null} (even if those resources had been updated previously). {@code
+   * oldResource} is also {@code null} for delete events and for events triggered through the
+   * primary-to-secondary index.
+   *
+   * <p>Implementations must therefore handle a {@code null} {@code oldResource} gracefully and not
+   * rely on it being present for correctness — overriding this method is intended for edge cases
+   * only.
+   *
+   * @param newResource the current version of the secondary resource
+   * @param oldResource the previous version of the secondary resource, or {@code null} if not
+   *     available (see above)
+   * @return set of primary resource IDs to enqueue for reconciliation
+   */
+  default Set<ResourceID> toPrimaryResourceIDs(R newResource, R oldResource) {
+    return toPrimaryResourceIDs(newResource);
+  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/SecondaryToPrimaryMapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/SecondaryToPrimaryMapper.java
@@ -30,12 +30,12 @@ public interface SecondaryToPrimaryMapper<R> {
   /**
    * Maps a secondary resource to the set of primary resources that should be reconciled in
    * response. Implementing this single-argument form is sufficient for the vast majority of use
-   * cases — prefer it unless you specifically need access to the previous version of the
-   * secondary resource (see {@link #toPrimaryResourceIDs(Object, Object)}).
+   * cases — prefer it unless you specifically need access to the previous version of the secondary
+   * resource (see {@link #toPrimaryResourceIDs(Object, Object)}).
    *
    * @param resource the secondary resource for which an event was received
-   * @return set of primary resource IDs to enqueue for reconciliation; an empty set means the
-   *     event is irrelevant and no reconciliation is triggered
+   * @return set of primary resource IDs to enqueue for reconciliation; an empty set means the event
+   *     is irrelevant and no reconciliation is triggered
    */
   Set<ResourceID> toPrimaryResourceIDs(R resource);
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/SecondaryToPrimaryMapper.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/SecondaryToPrimaryMapper.java
@@ -60,7 +60,8 @@ public interface SecondaryToPrimaryMapper<R> {
    *
    * <p>Implementations must therefore handle a {@code null} {@code oldResource} gracefully and not
    * rely on it being present for correctness — overriding this method is intended for edge cases
-   * only.
+   * only. Genericly speaking controller should also handle such change checking during
+   * reconciliation, so when controller starts and event is missed it is properly reconiled.
    *
    * @param newResource the current version of the secondary resource
    * @param oldResource the previous version of the secondary resource, or {@code null} if not

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/DefaultPrimaryToSecondaryIndex.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/DefaultPrimaryToSecondaryIndex.java
@@ -33,7 +33,8 @@ class DefaultPrimaryToSecondaryIndex<R extends HasMetadata> implements PrimaryTo
 
   @Override
   public synchronized void onAddOrUpdate(R resource) {
-    Set<ResourceID> primaryResources = secondaryToPrimaryMapper.toPrimaryResourceIDs(resource);
+    Set<ResourceID> primaryResources =
+        secondaryToPrimaryMapper.toPrimaryResourceIDs(resource, null);
     primaryResources.forEach(
         primaryResource -> {
           var resourceSet =
@@ -44,7 +45,8 @@ class DefaultPrimaryToSecondaryIndex<R extends HasMetadata> implements PrimaryTo
 
   @Override
   public synchronized void onDelete(R resource) {
-    Set<ResourceID> primaryResources = secondaryToPrimaryMapper.toPrimaryResourceIDs(resource);
+    Set<ResourceID> primaryResources =
+        secondaryToPrimaryMapper.toPrimaryResourceIDs(resource, null);
     primaryResources.forEach(
         primaryResource -> {
           var secondaryResources = index.get(primaryResource);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -130,7 +130,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
           primaryToSecondaryIndex.onDelete(resource);
           if (eventAcceptedByFilter(
               ResourceAction.DELETED, resource, null, deletedFinalStateUnknown)) {
-            propagateEvent(resource);
+            propagateEvent(resource, null);
           }
         });
   }
@@ -166,7 +166,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
           action,
           resource.getMetadata().getResourceVersion());
     }
-    propagateEvent(resource);
+    propagateEvent(resource, oldResource);
   }
 
   @Override
@@ -194,13 +194,13 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
           "Propagating event for {}, resource with same version not result of a our update.",
           action);
       var event = resultEvent.get();
-      propagateEvent((R) event.getResource().orElseThrow());
+      propagateEvent((R) event.getResource().orElseThrow(), oldObject);
     } else {
       log.debug("Event filtered out for operation: {}, resourceID: {}", action, resourceID);
     }
   }
 
-  private void propagateEvent(R resource, R oldResource) {
+  void propagateEvent(R resource, R oldResource) {
     var primaryResourceIdSet =
         configuration().getSecondaryToPrimaryMapper().toPrimaryResourceIDs(resource, oldResource);
     if (primaryResourceIdSet.isEmpty()) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -200,9 +200,9 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
     }
   }
 
-  protected void propagateEvent(R object) {
+  private void propagateEvent(R resource, R oldResource) {
     var primaryResourceIdSet =
-        configuration().getSecondaryToPrimaryMapper().toPrimaryResourceIDs(object);
+        configuration().getSecondaryToPrimaryMapper().toPrimaryResourceIDs(resource, oldResource);
     if (primaryResourceIdSet.isEmpty()) {
       return;
     }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
@@ -85,7 +85,7 @@ class InformerEventSourceTest {
     SecondaryToPrimaryMapper secondaryToPrimaryMapper = mock(SecondaryToPrimaryMapper.class);
     when(informerEventSourceConfiguration.getSecondaryToPrimaryMapper())
         .thenReturn(secondaryToPrimaryMapper);
-    when(secondaryToPrimaryMapper.toPrimaryResourceIDs(any()))
+    when(secondaryToPrimaryMapper.toPrimaryResourceIDs(any(), any()))
         .thenReturn(Set.of(ResourceID.fromResource(testDeployment())));
     when(informerEventSourceConfiguration.getInformerConfig()).thenReturn(informerConfig);
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
@@ -745,14 +745,16 @@ class InformerEventSourceTest {
     await()
         .pollDelay(Duration.ofMillis(70))
         .timeout(Duration.ofMillis(150))
-        .untilAsserted(() -> verify(informerEventSource, never()).propagateEvent(any()));
+        .untilAsserted(() -> verify(informerEventSource, never()).propagateEvent(any(), any()));
   }
 
   private void expectPropagateEvent(Deployment newResourceVersion) {
     await()
         .atMost(Duration.ofSeconds(1))
         .untilAsserted(
-            () -> verify(informerEventSource, times(1)).propagateEvent(newResourceVersion));
+            () ->
+                verify(informerEventSource, times(1))
+                    .propagateEvent(eq(newResourceVersion), any()));
   }
 
   private void expectHandleUpdateEvent(int newResourceVersion, int oldResourceVersion) {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/MappersTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/MappersTest.java
@@ -40,7 +40,8 @@ class MappersTest {
     var secondary = getConfigMap(primary);
     secondary.addOwnerReference(primary);
 
-    var res = Mappers.fromOwnerReferences(TestCustomResource.class).toPrimaryResourceIDs(secondary);
+    var res =
+        Mappers.fromOwnerReferences(TestCustomResource.class).toPrimaryResourceIDs(secondary, null);
 
     assertThat(res).contains(ResourceID.fromResource(primary));
   }
@@ -65,7 +66,7 @@ class MappersTest {
             .build();
     secondary.addOwnerReference(primary);
 
-    var res = Mappers.fromOwnerReferences(ConfigMap.class).toPrimaryResourceIDs(secondary);
+    var res = Mappers.fromOwnerReferences(ConfigMap.class).toPrimaryResourceIDs(secondary, null);
 
     assertThat(res).contains(ResourceID.fromResource(primary));
   }
@@ -79,7 +80,7 @@ class MappersTest {
 
     var res =
         Mappers.fromOwnerReferences(TestCustomResourceOtherV1.class)
-            .toPrimaryResourceIDs(secondary);
+            .toPrimaryResourceIDs(secondary, null);
 
     assertThat(res).isEmpty();
   }
@@ -103,7 +104,7 @@ class MappersTest {
                 HasMetadata.getGroup(TestCustomResource.class) + "/v2",
                 HasMetadata.getKind(TestCustomResource.class),
                 false)
-            .toPrimaryResourceIDs(secondary);
+            .toPrimaryResourceIDs(secondary, null);
 
     assertThat(res).contains(ResourceID.fromResource(primary));
   }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/PrimaryToSecondaryIndexTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/PrimaryToSecondaryIndexTest.java
@@ -46,7 +46,7 @@ class PrimaryToSecondaryIndexTest {
 
   @BeforeEach
   void setup() {
-    when(secondaryToPrimaryMapperMock.toPrimaryResourceIDs(any()))
+    when(secondaryToPrimaryMapperMock.toPrimaryResourceIDs(any(), any()))
         .thenReturn(Set.of(primaryID1, primaryID2));
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/ConfigCustomResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/ConfigCustomResource.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.secondarytoprimaryreferencechange;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Kind;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+/**
+ * Secondary resource that references a {@link TargetCustomResource} via {@code spec.targetName} and
+ * serves as input for it.
+ */
+@Group("sample.javaoperatorsdk")
+@Version("v1")
+@Kind("SecondaryToPrimaryRefConfig")
+@ShortNames("s2pconfig")
+public class ConfigCustomResource extends CustomResource<ConfigSpec, Void> implements Namespaced {}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/ConfigSpec.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/ConfigSpec.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.secondarytoprimaryreferencechange;
+
+public class ConfigSpec {
+
+  /**
+   * Name of the {@link TargetCustomResource} (in the same namespace) this config provides input.
+   */
+  private String targetName;
+
+  /** Value to be applied to the referenced target's status. */
+  private String value;
+
+  public String getTargetName() {
+    return targetName;
+  }
+
+  public ConfigSpec setTargetName(String targetName) {
+    this.targetName = targetName;
+    return this;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public ConfigSpec setValue(String value) {
+    this.value = value;
+    return this;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/ConfigToTargetMapper.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/ConfigToTargetMapper.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.secondarytoprimaryreferencechange;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
+
+/**
+ * Maps a {@link ConfigCustomResource} (secondary) to the {@link TargetCustomResource} (primary) it
+ * references via {@code spec.targetName}.
+ *
+ * <p>The interesting case is handling a <em>reference change</em>: when {@code spec.targetName} is
+ * edited to point from one target to another, both targets must be reconciled — the previously
+ * referenced one so it can fall back to its default value, and the newly referenced one so it can
+ * pick up the config's value. The single-argument mapper only knows about the new reference, so it
+ * would only enqueue the new target, leaving the old target with a stale value. By overriding the
+ * two-argument variant we additionally enqueue the old target whenever the reference moved.
+ */
+public class ConfigToTargetMapper implements SecondaryToPrimaryMapper<ConfigCustomResource> {
+
+  @Override
+  public Set<ResourceID> toPrimaryResourceIDs(ConfigCustomResource config) {
+    var targetName = config.getSpec().getTargetName();
+    if (targetName == null || targetName.isBlank()) {
+      return Set.of();
+    }
+    return Set.of(new ResourceID(targetName, config.getMetadata().getNamespace()));
+  }
+
+  @Override
+  public Set<ResourceID> toPrimaryResourceIDs(
+      ConfigCustomResource newConfig, ConfigCustomResource oldConfig) {
+    var result = new HashSet<>(toPrimaryResourceIDs(newConfig));
+    // oldConfig is only populated for genuine update events while the controller is running; for
+    // adds, deletes and startup it is null and there is no previous reference to reconcile.
+    if (oldConfig != null) {
+      result.addAll(toPrimaryResourceIDs(oldConfig));
+    }
+    return result;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/SecondaryToPrimaryReferenceChangeIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/SecondaryToPrimaryReferenceChangeIT.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.secondarytoprimaryreferencechange;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.javaoperatorsdk.annotation.Sample;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+
+import static io.javaoperatorsdk.operator.baseapi.secondarytoprimaryreferencechange.TargetReconciler.DEFAULT_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Sample(
+    tldr = "Handling a Secondary Resource Whose Reference to a Primary Changes",
+    description =
+        """
+        Demonstrates a configuration custom resource (the secondary) that references a target \
+        custom resource (the primary) via a spec field and serves as input for it. The target is \
+        reconciled so that, if a config references it, it takes the value from that config; \
+        otherwise it falls back to a default. The test shows how to handle the config's reference \
+        changing from one target to another: a SecondaryToPrimaryMapper that overrides the \
+        two-argument variant enqueues both the previously referenced target (so it reverts to the \
+        default) and the newly referenced one (so it picks up the value).
+        """)
+class SecondaryToPrimaryReferenceChangeIT {
+
+  static final String TARGET_A = "target-a";
+  static final String TARGET_B = "target-b";
+  static final String CONFIG_NAME = "config";
+  static final String CONFIG_VALUE = "value-from-config";
+
+  @RegisterExtension
+  LocallyRunOperatorExtension operator =
+      LocallyRunOperatorExtension.builder()
+          .withAdditionalCustomResourceDefinition(ConfigCustomResource.class)
+          .withReconciler(new TargetReconciler())
+          .build();
+
+  @Test
+  void targetTakesValueFromReferencingConfigAndHandlesReferenceChange() {
+    operator.create(target(TARGET_A));
+    operator.create(target(TARGET_B));
+
+    // With no config, both targets fall back to the default value.
+    awaitTargetValue(TARGET_A, DEFAULT_VALUE);
+    awaitTargetValue(TARGET_B, DEFAULT_VALUE);
+
+    // A config referencing target A makes A take the config's value; B stays on the default.
+    var config = operator.create(config(TARGET_A));
+    awaitTargetValue(TARGET_A, CONFIG_VALUE);
+    awaitTargetValue(TARGET_B, DEFAULT_VALUE);
+
+    // Moving the reference from A to B reconciles both: A reverts to the default and B picks it up.
+    config.getSpec().setTargetName(TARGET_B);
+    operator.replace(config);
+
+    awaitTargetValue(TARGET_B, CONFIG_VALUE);
+    awaitTargetValue(TARGET_A, DEFAULT_VALUE);
+  }
+
+  private void awaitTargetValue(String name, String expectedValue) {
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () -> {
+              var target = operator.get(TargetCustomResource.class, name);
+              assertThat(target.getStatus()).isNotNull();
+              assertThat(target.getStatus().getValue()).isEqualTo(expectedValue);
+            });
+  }
+
+  private TargetCustomResource target(String name) {
+    var target = new TargetCustomResource();
+    target.setMetadata(new ObjectMetaBuilder().withName(name).build());
+    return target;
+  }
+
+  private ConfigCustomResource config(String targetName) {
+    var config = new ConfigCustomResource();
+    config.setMetadata(new ObjectMetaBuilder().withName(CONFIG_NAME).build());
+    config.setSpec(new ConfigSpec().setTargetName(targetName).setValue(CONFIG_VALUE));
+    return config;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetCustomResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetCustomResource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.secondarytoprimaryreferencechange;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Kind;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+/**
+ * Primary resource that is reconciled. Its desired status value is provided by a {@link
+ * ConfigCustomResource} that references it (see {@link TargetReconciler}); when no config
+ * references it, a default value is used.
+ */
+@Group("sample.javaoperatorsdk")
+@Version("v1")
+@Kind("SecondaryToPrimaryRefTarget")
+@ShortNames("s2ptarget")
+public class TargetCustomResource extends CustomResource<Void, TargetStatus>
+    implements Namespaced {}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetReconciler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.secondarytoprimaryreferencechange;
+
+import java.util.List;
+
+import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
+
+/**
+ * Reconciles {@link TargetCustomResource}s. The desired status value comes from a {@link
+ * ConfigCustomResource} that references the target via {@code spec.targetName}; if no config
+ * references the target, {@link #DEFAULT_VALUE} is used.
+ *
+ * <p>{@link ConfigCustomResource}s are watched as secondary resources through an {@link
+ * InformerEventSource} configured with {@link ConfigToTargetMapper}, so changes to a config trigger
+ * reconciliation of the referenced target(s).
+ */
+@ControllerConfiguration
+public class TargetReconciler implements Reconciler<TargetCustomResource> {
+
+  public static final String DEFAULT_VALUE = "default";
+
+  @Override
+  public List<EventSource<?, TargetCustomResource>> prepareEventSources(
+      EventSourceContext<TargetCustomResource> context) {
+
+    var configuration =
+        InformerEventSourceConfiguration.from(
+                ConfigCustomResource.class, TargetCustomResource.class)
+            .withSecondaryToPrimaryMapper(new ConfigToTargetMapper())
+            .withPrimaryToSecondaryMapper(p -> null)
+            .build();
+
+    var ies = new InformerEventSource<>(configuration, context);
+    return List.of(ies);
+  }
+
+  @Override
+  public UpdateControl<TargetCustomResource> reconcile(
+      TargetCustomResource target, Context<TargetCustomResource> context) {
+
+    // There may be a stale secondary mapping after a reference change (the primary-to-secondary
+    // index does not remove the old association), so we also verify here that the config actually
+    // references this target. This makes reconciliation robust regardless of how the event arrived.
+    var value =
+        context.getSecondaryResources(ConfigCustomResource.class).stream()
+            .filter(
+                config -> target.getMetadata().getName().equals(config.getSpec().getTargetName()))
+            .map(config -> config.getSpec().getValue())
+            .findFirst()
+            .orElse(DEFAULT_VALUE);
+
+    target.setStatus(new TargetStatus().setValue(value));
+    return UpdateControl.patchStatus(target);
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetReconciler.java
@@ -48,7 +48,6 @@ public class TargetReconciler implements Reconciler<TargetCustomResource> {
         InformerEventSourceConfiguration.from(
                 ConfigCustomResource.class, TargetCustomResource.class)
             .withSecondaryToPrimaryMapper(new ConfigToTargetMapper())
-            .withPrimaryToSecondaryMapper(p -> null)
             .build();
 
     var ies = new InformerEventSource<>(configuration, context);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetStatus.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetStatus.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.secondarytoprimaryreferencechange;
+
+public class TargetStatus {
+
+  private String value;
+
+  public String getValue() {
+    return value;
+  }
+
+  public TargetStatus setValue(String value) {
+    this.value = value;
+    return this;
+  }
+}


### PR DESCRIPTION
This might needed in some corner cases where might help with optimizations to which resource to trigger.

TODO adaptor

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
