### PR TITLE
Add write permission to release-project-in-dir workflow

### DIFF
--- a/.github/workflows/release-project-in-dir.yml
+++ b/.github/workflows/release-project-in-dir.yml
@@ -53,6 +53,8 @@ jobs:
   update-working-version:
     runs-on: ubuntu-latest
     needs: publish
+    permissions:
+      contents: write
     if: "!contains(github.event.release.tag_name, 'RC')" # not sure we should keep this the RC part
     steps:
       - name: Checkout "${{inputs.version_branch}}" branch


### PR DESCRIPTION
This might fix https://github.com/operator-framework/java-operator-sdk/actions/runs/27014681537/job/79728388342#logs.