### PR TITLE
fix: release under-processing state on transient cache miss in ReconcilerExecutor

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -532,6 +532,10 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
             }
           } else {
             log.debug("Skipping execution; primary resource missing from cache");
+            // release the under-processing state, otherwise the resource is
+            // wedged: every subsequent event would be skipped with
+            // "Controller in execution: true" until the process restarts
+            eventProcessingFinished(executionScope, PostExecutionControl.defaultDispatch());
             return;
           }
         }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventProcessorTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/EventProcessorTest.java
@@ -124,6 +124,37 @@ class EventProcessorTest {
   }
 
   @Test
+  void recoversWhenResourceTransientlyMissingFromCacheAtExecutorRun() {
+    // submitReconciliationExecution sees the resource in the cache and
+    // dispatches a ReconcilerExecutor, but by the time the executor thread
+    // runs, the resource has transiently vanished from the informer cache
+    // (e.g. relist / watch-reconnect race). The executor must release the
+    // under-processing state on that early return; otherwise the resource
+    // state is wedged and every subsequent event is skipped forever
+    // ("Skipping executing controller. Controller in execution: true").
+    when(reconciliationDispatcherMock.handleExecution(any()))
+        .thenReturn(PostExecutionControl.defaultDispatch());
+    ResourceID resourceID = new ResourceID(UUID.randomUUID().toString(), TEST_NAMESPACE);
+    TestCustomResource customResource = testCustomResource(resourceID);
+    when(controllerEventSourceMock.get(eq(resourceID)))
+        .thenReturn(Optional.of(customResource)) // submit-time presence check
+        .thenReturn(Optional.empty()) // executor-run read: transient miss
+        .thenReturn(Optional.of(customResource)); // cache repopulated
+
+    eventProcessor.handleEvent(
+        new ResourceEvent(ResourceAction.UPDATED, resourceID, customResource));
+    // wait until the executor performed its cache read and hit the miss
+    verify(controllerEventSourceMock, timeout(SEPARATE_EXECUTION_TIMEOUT).atLeast(2))
+        .get(eq(resourceID));
+
+    eventProcessor.handleEvent(
+        new ResourceEvent(ResourceAction.UPDATED, resourceID, customResource));
+
+    verify(reconciliationDispatcherMock, timeout(SEPARATE_EXECUTION_TIMEOUT).times(1))
+        .handleExecution(any());
+  }
+
+  @Test
   void skipProcessingIfLatestCustomResourceNotInCache() {
     Event event = prepareCREvent();
     when(controllerEventSourceMock.get(event.getRelatedCustomResourceID()))


### PR DESCRIPTION
Fixes #3416

`ReconcilerExecutor.run()` returned without `eventProcessingFinished()` when the primary resource was transiently missing from the informer cache (and `triggerOnAllEvents()` is false). Since `submitReconciliationExecution` had already set `underProcessing = true` and consumed the event mark, the resource state was wedged permanently: every subsequent event for that resource — spec updates, `deletionTimestamp`, finalizer changes, retry/reschedule timer events — was skipped with `"Skipping executing controller. Controller in execution: true"` (DEBUG-only, so invisible in production logs) until the operator process restarted. Symptoms in the wild: CRs stuck in `Terminating` with their finalizer, or freshly created CRs that never receive a first reconcile.

The fix mirrors the adjacent delete-event branch: release the state via `eventProcessingFinished(executionScope, PostExecutionControl.defaultDispatch())`, which unsets `underProcessing`, purges state via `cleanupForDeletedEvent` if a delete event arrived meanwhile, and re-submits if new events were buffered (by which time the cache is typically repopulated).

Includes a deterministic regression test (`recoversWhenResourceTransientlyMissingFromCacheAtExecutorRun`): the cache returns the resource at submit time, `Optional.empty()` at the executor's read, then the resource again; a follow-up event must reach `handleExecution`. The test fails on the unpatched code ("Wanted but not invoked") and passes with the fix. Full `operator-framework-core` suite: 506 tests, 0 failures.