### PR TITLE
docs: fix diff link for 5.4 in release blog post

### DIFF
--- a/docs/content/en/blog/releases/v5-4-release.md
+++ b/docs/content/en/blog/releases/v5-4-release.md
@@ -173,7 +173,7 @@ Mappers.fromOwnerReferences(MyPrimary.class, clusterScoped);
 
 ## All Changes
 
-See the [comparison view](https://github.com/operator-framework/java-operator-sdk/compare/v5.3.0...v5.4.0)
+See the [comparison view](https://github.com/operator-framework/java-operator-sdk/compare/v5.3.5...v5.4.0)
 for the full list of changes.
 
 ## Feedback


### PR DESCRIPTION
This should be rather point to latest minor release of 5.3.x (not the first one).

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
