### PR TITLE
fix: event filtering edge case with no-op updates

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
@@ -31,6 +31,7 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 import io.javaoperatorsdk.operator.processing.event.source.informer.ManagedInformerEventSource;
 
+import static io.javaoperatorsdk.operator.api.reconciler.Experimental.API_MIGHT_CHANGE;
 import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getUID;
 import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getVersion;
 
@@ -71,6 +72,7 @@ public class ResourceOperations<P extends HasMetadata> {
     return serverSideApply(resource, (Options) null);
   }
 
+  @Experimental(API_MIGHT_CHANGE)
   public <R extends HasMetadata> R serverSideApply(R resource, Options options) {
     return resourcePatch(
         resource,
@@ -106,6 +108,7 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param informerEventSource InformerEventSource to use for resource caching and filtering
    * @param <R> resource type
    */
+  @Experimental(API_MIGHT_CHANGE)
   public <R extends HasMetadata> R serverSideApply(
       R resource, InformerEventSource<R, P> informerEventSource, Options options) {
     if (informerEventSource == null) {
@@ -123,7 +126,8 @@ public class ResourceOperations<P extends HasMetadata> {
                         .withFieldManager(context.getControllerConfiguration().fieldManager())
                         .withPatchType(PatchType.SERVER_SIDE_APPLY)
                         .build()),
-        informerEventSource);
+        informerEventSource,
+        options);
   }
 
   /**
@@ -235,6 +239,7 @@ public class ResourceOperations<P extends HasMetadata> {
    * @return updated resource
    * @param <R> resource type
    */
+  @Experimental(API_MIGHT_CHANGE)
   public <R extends HasMetadata> R update(R resource, Options options) {
     return resourcePatch(resource, r -> context.getClient().resource(r).update(), options);
   }
@@ -258,6 +263,7 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param informerEventSource InformerEventSource to use for resource caching and filtering
    * @param <R> resource type
    */
+  @Experimental(API_MIGHT_CHANGE)
   public <R extends HasMetadata> R update(
       R resource, InformerEventSource<R, P> informerEventSource, Options options) {
     if (informerEventSource == null) {
@@ -557,6 +563,7 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param <R> resource type
    * @throws IllegalStateException if no event source or multiple event sources are found
    */
+  @Experimental(API_MIGHT_CHANGE)
   @SuppressWarnings({"rawtypes", "unchecked"})
   public <R extends HasMetadata> R resourcePatch(
       R resource, UnaryOperator<R> updateOperation, Options options) {
@@ -794,10 +801,11 @@ public class ResourceOperations<P extends HasMetadata> {
     }
   }
 
-  @Experimental("This API might change")
   /**
    * Force filtering only if it is made sure that the update not results on a no-op change. See
-   * details here: https://github.com/operator-framework/java-operator-sdk/pull/3484
+   * details here: <a href="https://github.com/operator-framework/java-operator-sdk/pull/3484">PR
+   * 3484</a>
    */
+  @Experimental("This API might change")
   public record Options(boolean forceEventFiltering) {}
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
@@ -145,7 +145,7 @@ public class ResourceOperations<P extends HasMetadata> {
    * @return updated resource
    * @param <R> resource type
    */
-  public <R extends HasMetadata> R serverSideApplyStatus(R resource) {
+  public <R extends HasMetadata> R serverSideApplyStatus(R resource, Options options) {
     return resourcePatch(
         resource,
         r ->
@@ -158,7 +158,12 @@ public class ResourceOperations<P extends HasMetadata> {
                         .withForce(true)
                         .withFieldManager(context.getControllerConfiguration().fieldManager())
                         .withPatchType(PatchType.SERVER_SIDE_APPLY)
-                        .build()));
+                        .build()),
+        options);
+  }
+
+  public <R extends HasMetadata> R serverSideApplyStatus(R resource) {
+    return serverSideApplyStatus(resource, null);
   }
 
   /**
@@ -246,7 +251,7 @@ public class ResourceOperations<P extends HasMetadata> {
 
   public <R extends HasMetadata> R update(
       R resource, InformerEventSource<R, P> informerEventSource) {
-    return update(resource, informerEventSource, null);
+    return update(resource, informerEventSource, new Options(true));
   }
 
   /**
@@ -334,7 +339,8 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param <R> resource type
    */
   public <R extends HasMetadata> R updateStatus(R resource) {
-    return resourcePatch(resource, r -> context.getClient().resource(r).updateStatus());
+    return resourcePatch(
+        resource, r -> context.getClient().resource(r).updateStatus(), new Options(true));
   }
 
   /**
@@ -397,7 +403,13 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param <R> resource type
    */
   public <R extends HasMetadata> R jsonPatch(R resource, UnaryOperator<R> unaryOperator) {
-    return resourcePatch(resource, r -> context.getClient().resource(r).edit(unaryOperator));
+    return jsonPatch(resource, unaryOperator, null);
+  }
+
+  public <R extends HasMetadata> R jsonPatch(
+      R resource, UnaryOperator<R> unaryOperator, Options options) {
+    return resourcePatch(
+        resource, r -> context.getClient().resource(r).edit(unaryOperator), options);
   }
 
   /**
@@ -417,8 +429,14 @@ public class ResourceOperations<P extends HasMetadata> {
    * @return updated resource
    * @param <R> resource type
    */
+  public <R extends HasMetadata> R jsonPatchStatus(
+      R resource, UnaryOperator<R> unaryOperator, Options options) {
+    return resourcePatch(
+        resource, r -> context.getClient().resource(r).editStatus(unaryOperator), options);
+  }
+
   public <R extends HasMetadata> R jsonPatchStatus(R resource, UnaryOperator<R> unaryOperator) {
-    return resourcePatch(resource, r -> context.getClient().resource(r).editStatus(unaryOperator));
+    return jsonPatchStatus(resource, unaryOperator, null);
   }
 
   /**
@@ -482,7 +500,11 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param <R> resource type
    */
   public <R extends HasMetadata> R jsonMergePatch(R resource) {
-    return resourcePatch(resource, r -> context.getClient().resource(r).patch());
+    return jsonMergePatch(resource, null);
+  }
+
+  public <R extends HasMetadata> R jsonMergePatch(R resource, Options options) {
+    return resourcePatch(resource, r -> context.getClient().resource(r).patch(), options);
   }
 
   /**
@@ -501,7 +523,11 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param <R> resource type
    */
   public <R extends HasMetadata> R jsonMergePatchStatus(R resource) {
-    return resourcePatch(resource, r -> context.getClient().resource(r).patchStatus());
+    return jsonMergePatchStatus(resource, null);
+  }
+
+  public <R extends HasMetadata> R jsonMergePatchStatus(R resource, Options options) {
+    return resourcePatch(resource, r -> context.getClient().resource(r).patchStatus(), options);
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
@@ -68,6 +68,10 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param <R> resource type
    */
   public <R extends HasMetadata> R serverSideApply(R resource) {
+    return serverSideApply(resource, (Options) null);
+  }
+
+  public <R extends HasMetadata> R serverSideApply(R resource, Options options) {
     return resourcePatch(
         resource,
         r ->
@@ -79,7 +83,13 @@ public class ResourceOperations<P extends HasMetadata> {
                         .withForce(true)
                         .withFieldManager(context.getControllerConfiguration().fieldManager())
                         .withPatchType(PatchType.SERVER_SIDE_APPLY)
-                        .build()));
+                        .build()),
+        options);
+  }
+
+  public <R extends HasMetadata> R serverSideApply(
+      R resource, InformerEventSource<R, P> informerEventSource) {
+    return serverSideApply(resource, informerEventSource, null);
   }
 
   /**
@@ -97,7 +107,7 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param <R> resource type
    */
   public <R extends HasMetadata> R serverSideApply(
-      R resource, InformerEventSource<R, P> informerEventSource) {
+      R resource, InformerEventSource<R, P> informerEventSource, Options options) {
     if (informerEventSource == null) {
       return serverSideApply(resource);
     }
@@ -208,6 +218,10 @@ public class ResourceOperations<P extends HasMetadata> {
         context.eventSourceRetriever().getControllerEventSource());
   }
 
+  public <R extends HasMetadata> R update(R resource) {
+    return update(resource, (Options) null);
+  }
+
   /**
    * Updates the resource and caches the response if needed, thus making sure that next
    * reconciliation will see to updated resource - or more recent one if additional update happened
@@ -221,8 +235,13 @@ public class ResourceOperations<P extends HasMetadata> {
    * @return updated resource
    * @param <R> resource type
    */
-  public <R extends HasMetadata> R update(R resource) {
-    return resourcePatch(resource, r -> context.getClient().resource(r).update());
+  public <R extends HasMetadata> R update(R resource, Options options) {
+    return resourcePatch(resource, r -> context.getClient().resource(r).update(), options);
+  }
+
+  public <R extends HasMetadata> R update(
+      R resource, InformerEventSource<R, P> informerEventSource) {
+    return update(resource, informerEventSource, null);
   }
 
   /**
@@ -240,12 +259,12 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param <R> resource type
    */
   public <R extends HasMetadata> R update(
-      R resource, InformerEventSource<R, P> informerEventSource) {
+      R resource, InformerEventSource<R, P> informerEventSource, Options options) {
     if (informerEventSource == null) {
       return update(resource);
     }
     return resourcePatch(
-        resource, r -> context.getClient().resource(r).update(), informerEventSource);
+        resource, r -> context.getClient().resource(r).update(), informerEventSource, options);
   }
 
   /**
@@ -262,7 +281,8 @@ public class ResourceOperations<P extends HasMetadata> {
    * @param <R> resource type
    */
   public <R extends HasMetadata> R create(R resource) {
-    return resourcePatch(resource, r -> context.getClient().resource(r).create());
+    return resourcePatch(
+        resource, r -> context.getClient().resource(r).create(), new Options(true));
   }
 
   /**
@@ -284,8 +304,12 @@ public class ResourceOperations<P extends HasMetadata> {
     if (informerEventSource == null) {
       return create(resource);
     }
+    // it is safe to do event filtering for create since check if the resource already exists.
     return resourcePatch(
-        resource, r -> context.getClient().resource(r).create(), informerEventSource);
+        resource,
+        r -> context.getClient().resource(r).create(),
+        informerEventSource,
+        new Options(true));
   }
 
   /**
@@ -518,6 +542,10 @@ public class ResourceOperations<P extends HasMetadata> {
         context.eventSourceRetriever().getControllerEventSource());
   }
 
+  public <R extends HasMetadata> R resourcePatch(R resource, UnaryOperator<R> updateOperation) {
+    return resourcePatch(resource, updateOperation, (Options) null);
+  }
+
   /**
    * Utility method to patch a resource and cache the result. Automatically discovers the event
    * source for the resource type and delegates to {@link #resourcePatch(HasMetadata, UnaryOperator,
@@ -530,7 +558,8 @@ public class ResourceOperations<P extends HasMetadata> {
    * @throws IllegalStateException if no event source or multiple event sources are found
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
-  public <R extends HasMetadata> R resourcePatch(R resource, UnaryOperator<R> updateOperation) {
+  public <R extends HasMetadata> R resourcePatch(
+      R resource, UnaryOperator<R> updateOperation, Options options) {
 
     var esList = context.eventSourceRetriever().getEventSourcesFor(resource.getClass());
     if (esList.isEmpty()) {
@@ -544,7 +573,8 @@ public class ResourceOperations<P extends HasMetadata> {
           es.name());
     }
     if (es instanceof ManagedInformerEventSource mes) {
-      return resourcePatch(resource, updateOperation, (ManagedInformerEventSource<R, P, ?>) mes);
+      return resourcePatch(
+          resource, updateOperation, (ManagedInformerEventSource<R, P, ?>) mes, options);
     } else {
       throw new IllegalStateException(
           "Target event source must be a subclass off "
@@ -565,7 +595,16 @@ public class ResourceOperations<P extends HasMetadata> {
    */
   public <R extends HasMetadata> R resourcePatch(
       R resource, UnaryOperator<R> updateOperation, ManagedInformerEventSource<R, P, ?> ies) {
-    return ies.eventFilteringUpdateAndCacheResource(resource, updateOperation);
+    return resourcePatch(resource, updateOperation, ies, (Options) null);
+  }
+
+  public <R extends HasMetadata> R resourcePatch(
+      R resource,
+      UnaryOperator<R> updateOperation,
+      ManagedInformerEventSource<R, P, ?> ies,
+      Options options) {
+    return ies.eventFilteringUpdateAndCacheResource(
+        resource, updateOperation, options != null && options.forceEventFiltering());
   }
 
   /**
@@ -754,4 +793,11 @@ public class ResourceOperations<P extends HasMetadata> {
           e);
     }
   }
+
+  @Experimental("This API might change")
+  /**
+   * Force filtering only if it is made sure that the update not results on a no-op change. See
+   * details here: https://github.com/operator-framework/java-operator-sdk/pull/3484
+   */
+  public record Options(boolean forceEventFiltering) {}
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -30,6 +30,7 @@ import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfig
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.Ignore;
+import io.javaoperatorsdk.operator.api.reconciler.ResourceOperations;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ConfiguredDependentResource;
 import io.javaoperatorsdk.operator.processing.GroupVersionKind;
@@ -90,7 +91,6 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
         desired.getClass(),
         ResourceID.fromResource(desired),
         ssa);
-
     return ssa
         ? context.resourceOperations().serverSideApply(desired, eventSource().orElse(null))
         : context.resourceOperations().create(desired, eventSource().orElse(null));
@@ -114,7 +114,10 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
         ssa);
     if (ssa) {
       updatedResource =
-          context.resourceOperations().serverSideApply(desired, eventSource().orElse(null));
+          context
+              .resourceOperations()
+              .serverSideApply(
+                  desired, eventSource().orElse(null), new ResourceOperations.Options(true));
     } else {
       var updatedActual = GenericResourceUpdater.updateResource(actual, desired, context);
       updatedResource =

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
@@ -138,8 +138,7 @@ class ReconciliationDispatcher<P extends HasMetadata> {
       } else {
         updatedResource = context.resourceOperations().addFinalizer();
       }
-      return PostExecutionControl.onlyFinalizerAdded(updatedResource)
-          .withReSchedule(BaseControl.INSTANT_RESCHEDULE);
+      return PostExecutionControl.onlyFinalizerAdded(updatedResource);
     } else {
       try {
         return reconcileExecution(executionScope, resourceForExecution, originalResource, context);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -95,10 +95,10 @@ public abstract class ManagedInformerEventSource<
    */
   @SuppressWarnings("unchecked")
   public R eventFilteringUpdateAndCacheResource(
-      R resourceToUpdate, UnaryOperator<R> updateOperation) {
+      R resourceToUpdate, UnaryOperator<R> updateMethod) {
     if (resourceToUpdate.getMetadata().getResourceVersion() == null) {
       log.debug("No resourceVersion set. Skipping event filtering.");
-      return updateAndCacheResource(resourceToUpdate, updateOperation);
+      return updateAndCacheResource(resourceToUpdate, updateMethod);
     }
 
     ResourceID id = ResourceID.fromResource(resourceToUpdate);
@@ -107,7 +107,7 @@ public abstract class ManagedInformerEventSource<
     Set<ResourceID> relatedPrimaryIds = null;
     try {
       temporaryResourceCache.startEventFilteringModify(id);
-      updatedResource = updateOperation.apply(resourceToUpdate);
+      updatedResource = updateMethod.apply(resourceToUpdate);
       relatedPrimaryIds = cacheUpdateAndGetRelatedPrimaryIDs(updatedResource, resourceToUpdate);
       log.debug(
           "Caching resource update successful. id={}, rv={}",

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -39,6 +39,7 @@ import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.Informable;
 import io.javaoperatorsdk.operator.api.config.NamespaceChangeable;
+import io.javaoperatorsdk.operator.api.reconciler.Experimental;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.RecentOperationCacheFiller;
 import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import io.javaoperatorsdk.operator.health.InformerWrappingEventSourceHealthIndicator;
@@ -88,14 +89,23 @@ public abstract class ManagedInformerEventSource<
     }
   }
 
+  @Experimental(
+      "Internal API. Use ResourceOperation not this directly, this API might change in the future")
+  public R eventFilteringUpdateAndCacheResource(R resourceToUpdate, UnaryOperator<R> updateMethod) {
+    return eventFilteringUpdateAndCacheResource(resourceToUpdate, updateMethod, false);
+  }
+
   /**
    * Updates the resource and makes sure that the response is available for the next reconciliation.
    * Also makes sure that the even produced by this update is filtered, thus does not trigger the
    * reconciliation.
    */
+  @Experimental(
+      "Internal API. Use ResourceOperation not this directly, this API might change in the future")
   @SuppressWarnings("unchecked")
-  public R eventFilteringUpdateAndCacheResource(R resourceToUpdate, UnaryOperator<R> updateMethod) {
-    if (resourceToUpdate.getMetadata().getResourceVersion() == null) {
+  public R eventFilteringUpdateAndCacheResource(
+      R resourceToUpdate, UnaryOperator<R> updateMethod, boolean forceUpdateFilter) {
+    if (resourceToUpdate.getMetadata().getResourceVersion() == null && !forceUpdateFilter) {
       log.debug("No resourceVersion set. Skipping event filtering.");
       return updateAndCacheResource(resourceToUpdate, updateMethod);
     }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -94,8 +94,7 @@ public abstract class ManagedInformerEventSource<
    * reconciliation.
    */
   @SuppressWarnings("unchecked")
-  public R eventFilteringUpdateAndCacheResource(
-      R resourceToUpdate, UnaryOperator<R> updateMethod) {
+  public R eventFilteringUpdateAndCacheResource(R resourceToUpdate, UnaryOperator<R> updateMethod) {
     if (resourceToUpdate.getMetadata().getResourceVersion() == null) {
       log.debug("No resourceVersion set. Skipping event filtering.");
       return updateAndCacheResource(resourceToUpdate, updateMethod);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/ManagedInformerEventSource.java
@@ -94,14 +94,20 @@ public abstract class ManagedInformerEventSource<
    * reconciliation.
    */
   @SuppressWarnings("unchecked")
-  public R eventFilteringUpdateAndCacheResource(R resourceToUpdate, UnaryOperator<R> updateMethod) {
+  public R eventFilteringUpdateAndCacheResource(
+      R resourceToUpdate, UnaryOperator<R> updateOperation) {
+    if (resourceToUpdate.getMetadata().getResourceVersion() == null) {
+      log.debug("No resourceVersion set. Skipping event filtering.");
+      return updateAndCacheResource(resourceToUpdate, updateOperation);
+    }
+
     ResourceID id = ResourceID.fromResource(resourceToUpdate);
     log.debug("Starting event filtering and caching update for id={}", id);
     R updatedResource = null;
     Set<ResourceID> relatedPrimaryIds = null;
     try {
       temporaryResourceCache.startEventFilteringModify(id);
-      updatedResource = updateMethod.apply(resourceToUpdate);
+      updatedResource = updateOperation.apply(resourceToUpdate);
       relatedPrimaryIds = cacheUpdateAndGetRelatedPrimaryIDs(updatedResource, resourceToUpdate);
       log.debug(
           "Caching resource update successful. id={}, rv={}",
@@ -132,6 +138,12 @@ public abstract class ManagedInformerEventSource<
         log.debug("No new event present after the filtering update. id={}", id);
       }
     }
+  }
+
+  private R updateAndCacheResource(R resourceToUpdate, UnaryOperator<R> updateOperation) {
+    var result = updateOperation.apply(resourceToUpdate);
+    handleRecentResourceUpdate(ResourceID.fromResource(resourceToUpdate), result, resourceToUpdate);
+    return result;
   }
 
   protected abstract void handleEvent(

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperationsTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperationsTest.java
@@ -84,7 +84,7 @@ class ResourceOperationsTest {
 
     // Mock successful finalizer addition
     when(controllerEventSource.eventFilteringUpdateAndCacheResource(
-            any(), any(UnaryOperator.class)))
+            any(), any(UnaryOperator.class), anyBoolean()))
         .thenAnswer(
             invocation -> {
               var res = TestUtils.testCustomResource1();
@@ -99,7 +99,7 @@ class ResourceOperationsTest {
     assertThat(result.hasFinalizer(FINALIZER_NAME)).isTrue();
     assertThat(result.getMetadata().getResourceVersion()).isEqualTo("2");
     verify(controllerEventSource, times(1))
-        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class));
+        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class), anyBoolean());
   }
 
   @Test
@@ -111,7 +111,7 @@ class ResourceOperationsTest {
 
     // Mock successful SSA finalizer addition
     when(controllerEventSource.eventFilteringUpdateAndCacheResource(
-            any(), any(UnaryOperator.class)))
+            any(), any(UnaryOperator.class), anyBoolean()))
         .thenAnswer(
             invocation -> {
               var res = TestUtils.testCustomResource1();
@@ -126,7 +126,7 @@ class ResourceOperationsTest {
     assertThat(result.hasFinalizer(FINALIZER_NAME)).isTrue();
     assertThat(result.getMetadata().getResourceVersion()).isEqualTo("2");
     verify(controllerEventSource, times(1))
-        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class));
+        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class), anyBoolean());
   }
 
   @Test
@@ -139,7 +139,7 @@ class ResourceOperationsTest {
 
     // Mock successful finalizer removal
     when(controllerEventSource.eventFilteringUpdateAndCacheResource(
-            any(), any(UnaryOperator.class)))
+            any(), any(UnaryOperator.class), anyBoolean()))
         .thenAnswer(
             invocation -> {
               var res = TestUtils.testCustomResource1();
@@ -154,7 +154,7 @@ class ResourceOperationsTest {
     assertThat(result.hasFinalizer(FINALIZER_NAME)).isFalse();
     assertThat(result.getMetadata().getResourceVersion()).isEqualTo("2");
     verify(controllerEventSource, times(1))
-        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class));
+        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class), anyBoolean());
   }
 
   @Test
@@ -166,7 +166,7 @@ class ResourceOperationsTest {
 
     // First call throws conflict, second succeeds
     when(controllerEventSource.eventFilteringUpdateAndCacheResource(
-            any(), any(UnaryOperator.class)))
+            any(), any(UnaryOperator.class), anyBoolean()))
         .thenThrow(new KubernetesClientException("Conflict", 409, null))
         .thenAnswer(
             invocation -> {
@@ -184,7 +184,7 @@ class ResourceOperationsTest {
     assertThat(result).isNotNull();
     assertThat(result.hasFinalizer(FINALIZER_NAME)).isTrue();
     verify(controllerEventSource, times(2))
-        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class));
+        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class), anyBoolean());
     verify(resourceOp, times(1)).get();
   }
 
@@ -198,7 +198,7 @@ class ResourceOperationsTest {
 
     // First call throws conflict
     when(controllerEventSource.eventFilteringUpdateAndCacheResource(
-            any(), any(UnaryOperator.class)))
+            any(), any(UnaryOperator.class), anyBoolean()))
         .thenThrow(new KubernetesClientException("Conflict", 409, null));
 
     // Return null on retry (resource was deleted)
@@ -207,7 +207,7 @@ class ResourceOperationsTest {
     resourceOperations.removeFinalizer(FINALIZER_NAME);
 
     verify(controllerEventSource, times(1))
-        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class));
+        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class), anyBoolean());
     verify(resourceOp, times(1)).get();
   }
 
@@ -221,7 +221,7 @@ class ResourceOperationsTest {
 
     // First call throws unprocessable (422), second succeeds
     when(controllerEventSource.eventFilteringUpdateAndCacheResource(
-            any(), any(UnaryOperator.class)))
+            any(), any(UnaryOperator.class), anyBoolean()))
         .thenThrow(new KubernetesClientException("Unprocessable", 422, null))
         .thenAnswer(
             invocation -> {
@@ -243,7 +243,7 @@ class ResourceOperationsTest {
     assertThat(result.getMetadata().getResourceVersion()).isEqualTo("3");
     assertThat(result.hasFinalizer(FINALIZER_NAME)).isFalse();
     verify(controllerEventSource, times(2))
-        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class));
+        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class), anyBoolean());
     verify(resourceOp, times(1)).get();
   }
 
@@ -261,7 +261,8 @@ class ResourceOperationsTest {
     when(context.eventSourceRetriever()).thenReturn(eventSourceRetriever);
     when(eventSourceRetriever.getEventSourcesFor(TestCustomResource.class))
         .thenReturn(List.of(managedEventSource));
-    when(managedEventSource.eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class)))
+    when(managedEventSource.eventFilteringUpdateAndCacheResource(
+            any(), any(UnaryOperator.class), anyBoolean()))
         .thenReturn(updatedResource);
 
     var result = resourceOperations.resourcePatch(resource, UnaryOperator.identity());
@@ -269,7 +270,7 @@ class ResourceOperationsTest {
     assertThat(result).isNotNull();
     assertThat(result.getMetadata().getResourceVersion()).isEqualTo("2");
     verify(managedEventSource, times(1))
-        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class));
+        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class), anyBoolean());
   }
 
   @Test
@@ -303,7 +304,7 @@ class ResourceOperationsTest {
     resourceOperations.resourcePatch(resource, UnaryOperator.identity());
 
     verify(eventSource1, times(1))
-        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class));
+        .eventFilteringUpdateAndCacheResource(any(), any(UnaryOperator.class), anyBoolean());
   }
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
@@ -799,6 +799,28 @@ class InformerEventSourceTest {
     verify(eventHandlerMock, never()).handleEvent(any());
   }
 
+  @Test
+  void forceUpdateFilterOpensFilterWindowEvenWhenResourceVersionIsNull() {
+    // A write without a resourceVersion (e.g. an SSA finalizer add, which uses no optimistic
+    // locking) would normally skip event filtering. forceUpdateFilter=true forces filtering
+    // anyway so the resulting own event is correlated and does not trigger a spurious
+    // reconciliation.
+    var resourceToUpdate = testDeployment();
+    resourceToUpdate.getMetadata().setResourceVersion(null);
+    var updated = deploymentWithResourceVersion(3);
+    when(temporaryResourceCache.doneEventFilterModify(any())).thenReturn(Optional.empty());
+
+    var result =
+        informerEventSource.eventFilteringUpdateAndCacheResource(
+            resourceToUpdate, r -> updated, true);
+
+    assertThat(result).isSameAs(updated);
+    verify(temporaryResourceCache, times(1)).startEventFilteringModify(any());
+    verify(temporaryResourceCache, times(1)).doneEventFilterModify(any());
+    verify(temporaryResourceCache, times(1)).putResource(updated);
+    verify(eventHandlerMock, never()).handleEvent(any());
+  }
+
   private PrimaryToSecondaryIndex<Deployment> injectIndexMock() throws Exception {
     @SuppressWarnings("unchecked")
     PrimaryToSecondaryIndex<Deployment> indexMock = mock(PrimaryToSecondaryIndex.class);

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSourceTest.java
@@ -780,6 +780,25 @@ class InformerEventSourceTest {
     verify(eventHandlerMock, times(1)).handleEvent(any());
   }
 
+  @Test
+  void skipsEventFilteringWhenResourceVersionIsNull() {
+    // Without a resourceVersion there is nothing to correlate own-write echoes against, so
+    // event filtering is bypassed: the update is applied and cached directly, no filter window
+    // is opened and no event is propagated through handleEvent.
+    var resourceToUpdate = testDeployment();
+    resourceToUpdate.getMetadata().setResourceVersion(null);
+    var updated = deploymentWithResourceVersion(3);
+
+    var result =
+        informerEventSource.eventFilteringUpdateAndCacheResource(resourceToUpdate, r -> updated);
+
+    assertThat(result).isSameAs(updated);
+    verify(temporaryResourceCache, times(1)).putResource(updated);
+    verify(temporaryResourceCache, never()).startEventFilteringModify(any());
+    verify(temporaryResourceCache, never()).doneEventFilterModify(any());
+    verify(eventHandlerMock, never()).handleEvent(any());
+  }
+
   private PrimaryToSecondaryIndex<Deployment> injectIndexMock() throws Exception {
     @SuppressWarnings("unchecked")
     PrimaryToSecondaryIndex<Deployment> indexMock = mock(PrimaryToSecondaryIndex.class);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/changenamespace/ChangeNamespaceTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/changenamespace/ChangeNamespaceTestReconciler.java
@@ -53,7 +53,9 @@ public class ChangeNamespaceTestReconciler
       ChangeNamespaceTestCustomResource primary,
       Context<ChangeNamespaceTestCustomResource> context) {
 
-    context.resourceOperations().serverSideApply(configMap(primary));
+    context
+        .resourceOperations()
+        .serverSideApply(configMap(primary), new ResourceOperations.Options(true));
 
     if (primary.getStatus() == null) {
       primary.setStatus(new ChangeNamespaceTestCustomResourceStatus());

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/onrelistfilter/OnRelistFilterReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/onrelistfilter/OnRelistFilterReconciler.java
@@ -34,6 +34,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.ResourceOperations;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
@@ -79,7 +80,10 @@ public class OnRelistFilterReconciler implements Reconciler<OnRelistFilterCustom
     if (execution == 1) {
       var cm = prepareConfigMap(resource);
       switch (mode.get()) {
-        case NO_RELIST -> context.resourceOperations().serverSideApply(cm, configMapEventSource);
+        case NO_RELIST ->
+            context
+                .resourceOperations()
+                .serverSideApply(cm, configMapEventSource, new ResourceOperations.Options(true));
         case RELIST_AROUND_UPDATE -> {
           configMapEventSource.simulateOnBeforeList();
           var applied = context.resourceOperations().serverSideApply(cm, configMapEventSource);
@@ -94,7 +98,9 @@ public class OnRelistFilterReconciler implements Reconciler<OnRelistFilterCustom
         case RELIST_COMPLETES_BEFORE_UPDATE -> {
           configMapEventSource.simulateOnBeforeList();
           configMapEventSource.simulateOnList();
-          context.resourceOperations().serverSideApply(cm, configMapEventSource);
+          context
+              .resourceOperations()
+              .serverSideApply(cm, configMapEventSource, new ResourceOperations.Options(true));
         }
         case RELIST_STARTS_DURING_UPDATE -> {
           // Drive the event-filtering update path manually so we can fire onBeforeList AFTER the
@@ -114,7 +120,8 @@ public class OnRelistFilterReconciler implements Reconciler<OnRelistFilterCustom
                                 .withFieldManager(fieldManager)
                                 .withPatchType(PatchType.SERVER_SIDE_APPLY)
                                 .build());
-                  });
+                  },
+                  true);
           // See RELIST_AROUND_UPDATE: wait for the own-write event to be buffered while the
           // re-list is still in progress, so it is tagged as part of the re-list and propagated.
           configMapEventSource.awaitWatchEventReceived(applied);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/ownsecondaryupdate/OwnSecondaryUpdateReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/ownsecondaryupdate/OwnSecondaryUpdateReconciler.java
@@ -27,6 +27,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.ResourceOperations;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
@@ -50,7 +51,10 @@ public class OwnSecondaryUpdateReconciler implements Reconciler<OwnSecondaryUpda
     // version actually advances. With the read-cache-after-write filter in place, none of the
     // resulting watch events should trigger a fresh reconciliation.
     for (int i = 1; i <= OWN_SSA_COUNT; i++) {
-      context.resourceOperations().serverSideApply(prepareCM(resource, i), configMapEventSource);
+      context
+          .resourceOperations()
+          .serverSideApply(
+              prepareCM(resource, i), configMapEventSource, new ResourceOperations.Options(true));
     }
     return UpdateControl.noUpdate();
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchCustomResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchCustomResource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.readcacheafterwrite.specchangeduringstatuspatch;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.javaoperatorsdk")
+@Version("v1")
+@ShortNames("scdsp")
+public class SpecChangeDuringStatusPatchCustomResource
+    extends CustomResource<SpecChangeDuringStatusPatchSpec, SpecChangeDuringStatusPatchStatus>
+    implements Namespaced {}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchIT.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.readcacheafterwrite.specchangeduringstatuspatch;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+
+import static io.javaoperatorsdk.operator.baseapi.readcacheafterwrite.specchangeduringstatuspatch.SpecChangeDuringStatusPatchReconciler.STATUS_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Reproduces a concurrent spec change happening while the controller patches its own status. When
+ * the reconciler patches the status it opens an event filtering window so it does not re-trigger
+ * itself. This test changes the spec on the cluster while that window is open and verifies that the
+ * spec change is still reconciled - it must not be silently absorbed together with the controller's
+ * own status update.
+ */
+class SpecChangeDuringStatusPatchIT {
+
+  static final String RESOURCE_NAME = "test-resource";
+  static final String SPEC_VALUE = "initial";
+  public static final String UPDATED_SPEC_VALUE = "updated-val";
+
+  SpecChangeDuringStatusPatchReconciler reconciler = new SpecChangeDuringStatusPatchReconciler();
+
+  @RegisterExtension
+  LocallyRunOperatorExtension extension =
+      LocallyRunOperatorExtension.builder().withReconciler(reconciler).build();
+
+  @RepeatedTest(10)
+  void specChangeDuringStatusPatchIsReconciled() throws InterruptedException {
+    var res = extension.create(testResource());
+    var statusRes = testResource();
+    statusRes.getMetadata().setNamespace(res.getMetadata().getNamespace());
+    extension
+        .getKubernetesClient()
+        .resource(statusRes)
+        .status()
+        .patch(
+            new PatchContext.Builder()
+                .withForce(true)
+                .withFieldManager(
+                    SpecChangeDuringStatusPatchReconciler.class.getSimpleName().toLowerCase())
+                .withPatchType(PatchType.SERVER_SIDE_APPLY)
+                .build());
+
+    // wait until the reconciler is inside its own status patch, holding the filtering window open
+    assertThat(reconciler.statusPatchStartedLatch.await(30, TimeUnit.SECONDS))
+        .as("reconciler should enter its own status patch operation")
+        .isTrue();
+
+    // change the spec on the cluster while the controller's status patch is still in flight
+    var current = extension.get(SpecChangeDuringStatusPatchCustomResource.class, RESOURCE_NAME);
+    current.getSpec().setValue(UPDATED_SPEC_VALUE);
+    extension.replace(current);
+
+    // let the reconciler finish its own status patch
+    reconciler.specChangeDoneLatch.countDown();
+
+    // the spec change must be picked up by a fresh reconciliation and not lost with the own update
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              assertThat(reconciler.numberOfExecutions.get()).isGreaterThanOrEqualTo(2);
+              assertThat(reconciler.lastObservedSpecValue.get())
+                  .as("a later reconciliation must observe the externally-applied spec change")
+                  .isEqualTo(UPDATED_SPEC_VALUE);
+            });
+
+    // sanity check: the status the controller set is still present after the concurrent spec change
+    var updated = extension.get(SpecChangeDuringStatusPatchCustomResource.class, RESOURCE_NAME);
+    assertThat(updated.getSpec().getValue()).isEqualTo(UPDATED_SPEC_VALUE);
+    assertThat(updated.getStatus()).isNotNull();
+    assertThat(updated.getStatus().getValue()).isEqualTo(STATUS_VALUE);
+  }
+
+  SpecChangeDuringStatusPatchCustomResource testResource() {
+    var r = new SpecChangeDuringStatusPatchCustomResource();
+    r.setMetadata(new ObjectMetaBuilder().withName(RESOURCE_NAME).build());
+    r.setSpec(new SpecChangeDuringStatusPatchSpec().setValue(SPEC_VALUE));
+    r.setStatus(new SpecChangeDuringStatusPatchStatus().setValue(STATUS_VALUE));
+    return r;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchReconciler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.readcacheafterwrite.specchangeduringstatuspatch;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+
+/**
+ * On the first reconciliation the reconciler patches its own status, but keeps the event filtering
+ * window (opened by {@link
+ * io.javaoperatorsdk.operator.api.reconciler.ResourceOperations#resourcePatch}) open until the test
+ * signals that it has changed the spec on the cluster. This reproduces the race where a spec change
+ * lands while the controller's own status patch is in flight: the spec change event must still
+ * propagate as a fresh reconciliation, it must not be absorbed as if it were our own status update.
+ */
+@ControllerConfiguration
+public class SpecChangeDuringStatusPatchReconciler
+    implements Reconciler<SpecChangeDuringStatusPatchCustomResource> {
+
+  static final String STATUS_VALUE = "reconciled";
+
+  final AtomicInteger numberOfExecutions = new AtomicInteger();
+  final CountDownLatch statusPatchStartedLatch = new CountDownLatch(1);
+  final CountDownLatch specChangeDoneLatch = new CountDownLatch(1);
+  final AtomicReference<String> lastObservedSpecValue = new AtomicReference<>();
+
+  @Override
+  public UpdateControl<SpecChangeDuringStatusPatchCustomResource> reconcile(
+      SpecChangeDuringStatusPatchCustomResource resource,
+      Context<SpecChangeDuringStatusPatchCustomResource> context) {
+    int execution = numberOfExecutions.incrementAndGet();
+    lastObservedSpecValue.set(resource.getSpec().getValue());
+
+    if (execution == 1) {
+      resource.setStatus(new SpecChangeDuringStatusPatchStatus().setValue(STATUS_VALUE));
+      resource.getMetadata().setResourceVersion(null);
+      // Patch our own status, but hold the filtering window open with a hook that lets the test
+      // change the spec on the cluster WHILE the status patch is still in flight.
+      statusPatchStartedLatch.countDown();
+      try {
+        if (!specChangeDoneLatch.await(30, TimeUnit.SECONDS)) {
+          throw new IllegalStateException("timed out waiting for external spec change");
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException(e);
+      }
+      return UpdateControl.patchStatus(resource);
+    }
+    return UpdateControl.noUpdate();
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchSpec.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchSpec.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.readcacheafterwrite.specchangeduringstatuspatch;
+
+public class SpecChangeDuringStatusPatchSpec {
+
+  private String value;
+
+  public String getValue() {
+    return value;
+  }
+
+  public SpecChangeDuringStatusPatchSpec setValue(String value) {
+    this.value = value;
+    return this;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchStatus.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/specchangeduringstatuspatch/SpecChangeDuringStatusPatchStatus.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.baseapi.readcacheafterwrite.specchangeduringstatuspatch;
+
+public class SpecChangeDuringStatusPatchStatus {
+
+  private String value;
+
+  public String getValue() {
+    return value;
+  }
+
+  public SpecChangeDuringStatusPatchStatus setValue(String value) {
+    this.value = value;
+    return this;
+  }
+}


### PR DESCRIPTION
When an event-filtering and caching update results in a no-op (i.e., nothing changes on the resource), and there is a concurrent update that actually modifies the resource, the event from that concurrent update may be filtered out.

This is particularly problematic when we patch the primary resource's status and the patch is a no-op, while another actor concurrently changes the resource's spec. In this case, the spec change would not result in an update event.

Although we could handle this particular case in the code, there are other situations (such as two concurrent updates to a secondary resource without optimistic locking) where we want to avoid similar issues. Therefore, we now limit event filtering to updates performed using optimistic locking.

We recognize that this changes the previous behavior. However, since controllers are expected to be idempotent by default, we do not expect this to have a significant impact on users.

In next minor version we will prepare enhanced methods that user can use to optimize their specific use cases:
https://github.com/operator-framework/java-operator-sdk/issues/3483

Notes:
 - added options for forcing event filtering, that is needed to preserve functionality for Dependent Resources. Where that behavior is actually correct, since we match the resources. This could be used also if somebody want to still use
 
 
 TODO:
 - update javadocs, documentation, release create post.