### PR TITLE
feat: downgrade uncaught error log when reconciler handles the error

### DIFF
--- a/docs/content/en/docs/documentation/error-handling-retries.md
+++ b/docs/content/en/docs/documentation/error-handling-retries.md
@@ -108,6 +108,16 @@ Retry can be skipped in cases of unrecoverable errors:
  ErrorStatusUpdateControl.patchStatus(customResource).withNoRetry();
 ```
 
+When `updateErrorStatus` returns any `ErrorStatusUpdateControl` other than
+`ErrorStatusUpdateControl.defaultErrorProcessing()`, the framework considers the error handled by
+the reconciler. In that case the native retry (including the exponential backoff from
+`@GradualRetry`) is still performed, but the framework no longer logs the "Uncaught error during
+event processing" warning; the error is logged on `DEBUG` level instead. This lets a reconciler keep
+retrying an expected, recoverable condition without producing a continuous stream of `WARN` messages,
+while it remains free to log the error at whatever level it deems appropriate inside
+`updateErrorStatus`. Returning `ErrorStatusUpdateControl.defaultErrorProcessing()` preserves the
+default behavior, including the warning.
+
 ### Correctness and Automatic Retries
 
 While it is possible to deactivate automatic retries, this is not desirable unless there is a particular reason.

--- a/docs/content/en/docs/documentation/error-handling-retries.md
+++ b/docs/content/en/docs/documentation/error-handling-retries.md
@@ -111,12 +111,14 @@ Retry can be skipped in cases of unrecoverable errors:
 When `updateErrorStatus` returns any `ErrorStatusUpdateControl` other than
 `ErrorStatusUpdateControl.defaultErrorProcessing()`, the framework considers the error handled by
 the reconciler. In that case the native retry (including the exponential backoff from
-`@GradualRetry`) is still performed, but the framework no longer logs the "Uncaught error during
-event processing" warning; the error is logged on `DEBUG` level instead. This lets a reconciler keep
-retrying an expected, recoverable condition without producing a continuous stream of `WARN` messages,
-while it remains free to log the error at whatever level it deems appropriate inside
-`updateErrorStatus`. Returning `ErrorStatusUpdateControl.defaultErrorProcessing()` preserves the
-default behavior, including the warning.
+`@GradualRetry`) is still performed, and while retry attempts remain the framework no longer logs
+the "Uncaught error during event processing" warning; the error is logged on `DEBUG` level instead.
+This lets a reconciler keep retrying an expected, recoverable condition without producing a
+continuous stream of `WARN` messages, while it remains free to log the error at whatever level it
+deems appropriate inside `updateErrorStatus`. On the last retry attempt (or when no retry is
+configured), the failure is final, so the framework keeps its higher-severity logging to avoid
+hiding a non-recoverable error. Returning `ErrorStatusUpdateControl.defaultErrorProcessing()`
+preserves the default behavior, including the warning.
 
 ### Correctness and Automatic Retries
 

--- a/docs/content/en/docs/documentation/error-handling-retries.md
+++ b/docs/content/en/docs/documentation/error-handling-retries.md
@@ -110,15 +110,19 @@ Retry can be skipped in cases of unrecoverable errors:
 
 When `updateErrorStatus` returns any `ErrorStatusUpdateControl` other than
 `ErrorStatusUpdateControl.defaultErrorProcessing()`, the framework considers the error handled by
-the reconciler. In that case the native retry (including the exponential backoff from
-`@GradualRetry`) is still performed, and while retry attempts remain the framework no longer logs
-the "Uncaught error during event processing" warning; the error is logged on `DEBUG` level instead.
-This lets a reconciler keep retrying an expected, recoverable condition without producing a
-continuous stream of `WARN` messages, while it remains free to log the error at whatever level it
-deems appropriate inside `updateErrorStatus`. On the last retry attempt (or when no retry is
-configured), the failure is final, so the framework keeps its higher-severity logging to avoid
-hiding a non-recoverable error. Returning `ErrorStatusUpdateControl.defaultErrorProcessing()`
-preserves the default behavior, including the warning.
+the reconciler and, while retry attempts remain, no longer logs the "Uncaught error during event
+processing" warning; the error is logged on `DEBUG` level instead. This lets a reconciler keep
+retrying an expected, recoverable condition without producing a continuous stream of `WARN`
+messages, while it remains free to log the error at whatever level it deems appropriate inside
+`updateErrorStatus`.
+
+This log downgrade applies only when retry is actually taking place, i.e. a retry is configured and
+the returned control does not disable it. Controls that explicitly disable retry — `withNoRetry()`
+and `rescheduleAfter()` — cancel the native retry and its `@GradualRetry` backoff, so nothing is
+retried in those cases. Likewise, on the last retry attempt (or when no retry is configured) the
+failure is final, so the framework keeps its higher-severity logging to avoid hiding a
+non-recoverable error. Returning `ErrorStatusUpdateControl.defaultErrorProcessing()` preserves the
+default behavior, including the warning.
 
 ### Correctness and Automatic Retries
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -329,18 +329,13 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
   private void logErrorIfNoRetryConfigured(
       ExecutionScope<P> executionScope, PostExecutionControl<P> postExecutionControl) {
     if (!isRetryConfigured() && postExecutionControl.exceptionDuringExecution()) {
-      if (postExecutionControl.isErrorHandledByReconciler()) {
-        log.debug(
-            "Error during event processing {}, but was handled by the reconciler. (No retry"
-                + " configured)",
-            executionScope,
-            postExecutionControl.getRuntimeException().orElseThrow());
-      } else {
-        log.error(
-            "Error during event processing {}. (No retry configured)",
-            executionScope,
-            postExecutionControl.getRuntimeException().orElseThrow());
-      }
+      // No retry is configured, so this failure is final. Even if the reconciler handled the error
+      // in updateErrorStatus, we keep the higher-severity log so a non-recoverable failure is not
+      // hidden from operators.
+      log.error(
+          "Error during event processing {}",
+          executionScope,
+          postExecutionControl.getRuntimeException().orElseThrow());
     }
   }
 
@@ -423,9 +418,11 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
       boolean errorHandledByReconciler,
       Exception exception,
       ExecutionScope<P> executionScope) {
-    if (errorHandledByReconciler) {
+    if (errorHandledByReconciler && !retry.isLastAttempt()) {
       // The reconciler already handled the error in updateErrorStatus (and had the chance to log it
-      // as needed), so the framework only logs it on debug level while still retrying.
+      // as needed), so while there are retries remaining the framework only logs it on debug level.
+      // On the last attempt we still fall through to the higher-severity logging below, so a final,
+      // non-recoverable failure is not hidden from operators.
       log.debug(
           "Error during event processing {}, but was handled by the reconciler",
           executionScope,

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -297,7 +297,9 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
         && postExecutionControl.exceptionDuringExecution()
         && (!state.deleteEventPresent() || triggerOnAllEvents())) {
       handleRetryOnException(
-          executionScope, postExecutionControl.getRuntimeException().orElseThrow());
+          executionScope,
+          postExecutionControl.getRuntimeException().orElseThrow(),
+          postExecutionControl.isErrorHandledByReconciler());
       return;
     }
     cleanupOnSuccessfulExecution(executionScope);
@@ -327,10 +329,17 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
   private void logErrorIfNoRetryConfigured(
       ExecutionScope<P> executionScope, PostExecutionControl<P> postExecutionControl) {
     if (!isRetryConfigured() && postExecutionControl.exceptionDuringExecution()) {
-      log.error(
-          "Error during event processing {}",
-          executionScope,
-          postExecutionControl.getRuntimeException().orElseThrow());
+      if (postExecutionControl.isErrorHandledByReconciler()) {
+        log.debug(
+            "Error during event processing {}, but was handled by the reconciler",
+            executionScope,
+            postExecutionControl.getRuntimeException().orElseThrow());
+      } else {
+        log.error(
+            "Error during event processing {}",
+            executionScope,
+            postExecutionControl.getRuntimeException().orElseThrow());
+      }
     }
   }
 
@@ -369,14 +378,16 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
    * events (received meanwhile retry is in place or already in buffer) instantly or always wait
    * according to the retry timing if there was an exception.
    */
-  private void handleRetryOnException(ExecutionScope<P> executionScope, Exception exception) {
+  private void handleRetryOnException(
+      ExecutionScope<P> executionScope, Exception exception, boolean errorHandledByReconciler) {
     final var state = getOrInitRetryExecution(executionScope);
     var resourceID = state.getId();
     boolean eventPresent =
         state.eventPresent()
             || (triggerOnAllEvents() && state.isAdditionalEventPresentAfterDeleteEvent());
     state.markEventReceived(triggerOnAllEvents());
-    retryAwareErrorLogging(state.getRetry(), eventPresent, exception, executionScope);
+    retryAwareErrorLogging(
+        state.getRetry(), eventPresent, errorHandledByReconciler, exception, executionScope);
     metrics.reconciliationFailed(
         executionScope.getResource(), state.getRetry(), exception, metricsMetadata);
     if (eventPresent) {
@@ -408,9 +419,17 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
   private void retryAwareErrorLogging(
       RetryExecution retry,
       boolean eventPresent,
+      boolean errorHandledByReconciler,
       Exception exception,
       ExecutionScope<P> executionScope) {
-    if (!retry.isLastAttempt()
+    if (errorHandledByReconciler) {
+      // The reconciler already handled the error in updateErrorStatus (and had the chance to log it
+      // as needed), so the framework only logs it on debug level while still retrying.
+      log.debug(
+          "Error during event processing {}, but was handled by the reconciler",
+          executionScope,
+          exception);
+    } else if (!retry.isLastAttempt()
         && exception instanceof KubernetesClientException ex
         && ex.getCode() == HttpURLConnection.HTTP_CONFLICT) {
       log.debug("Full client conflict error during event processing {}", executionScope, exception);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -418,7 +418,18 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
       boolean errorHandledByReconciler,
       Exception exception,
       ExecutionScope<P> executionScope) {
-    if (errorHandledByReconciler && !retry.isLastAttempt()) {
+    if (!retry.isLastAttempt()
+        && exception instanceof KubernetesClientException ex
+        && ex.getCode() == HttpURLConnection.HTTP_CONFLICT) {
+      // The conflict branch is already low-noise (DEBUG + INFO) and provides actionable info, so it
+      // keeps precedence over the handled-error downgrade below.
+      log.debug("Full client conflict error during event processing {}", executionScope, exception);
+      log.info(
+          "Resource Kubernetes Resource Creator/Update Conflict during reconciliation. Message:"
+              + " {} Resource name: {}",
+          ex.getMessage(),
+          ex.getFullResourceName());
+    } else if (errorHandledByReconciler && !retry.isLastAttempt()) {
       // The reconciler already handled the error in updateErrorStatus (and had the chance to log it
       // as needed), so while there are retries remaining the framework only logs it on debug level.
       // On the last attempt we still fall through to the higher-severity logging below, so a final,
@@ -427,15 +438,6 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
           "Error during event processing {}, but was handled by the reconciler",
           executionScope,
           exception);
-    } else if (!retry.isLastAttempt()
-        && exception instanceof KubernetesClientException ex
-        && ex.getCode() == HttpURLConnection.HTTP_CONFLICT) {
-      log.debug("Full client conflict error during event processing {}", executionScope, exception);
-      log.info(
-          "Resource Kubernetes Resource Creator/Update Conflict during reconciliation. Message:"
-              + " {} Resource name: {}",
-          ex.getMessage(),
-          ex.getFullResourceName());
     } else if (eventPresent || !retry.isLastAttempt()) {
       log.warn(
           "Uncaught error during event processing {} - but another reconciliation will be attempted"

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -331,12 +331,13 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
     if (!isRetryConfigured() && postExecutionControl.exceptionDuringExecution()) {
       if (postExecutionControl.isErrorHandledByReconciler()) {
         log.debug(
-            "Error during event processing {}, but was handled by the reconciler",
+            "Error during event processing {}, but was handled by the reconciler. (No retry"
+                + " configured)",
             executionScope,
             postExecutionControl.getRuntimeException().orElseThrow());
       } else {
         log.error(
-            "Error during event processing {}",
+            "Error during event processing {}. (No retry configured)",
             executionScope,
             postExecutionControl.getRuntimeException().orElseThrow());
       }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/PostExecutionControl.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/PostExecutionControl.java
@@ -27,6 +27,7 @@ final class PostExecutionControl<R extends HasMetadata> {
   private final Exception runtimeException;
 
   private Long reScheduleDelay = null;
+  private boolean errorHandledByReconciler = false;
 
   private PostExecutionControl(
       boolean finalizerRemoved,
@@ -66,6 +67,22 @@ final class PostExecutionControl<R extends HasMetadata> {
   public static <R extends HasMetadata> PostExecutionControl<R> exceptionDuringExecution(
       Exception exception) {
     return new PostExecutionControl<>(false, null, false, exception);
+  }
+
+  /**
+   * Marks that the exception was handled by the reconciler's {@code updateErrorStatus} (i.e. the
+   * reconciler did not return {@link
+   * io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl#defaultErrorProcessing()}),
+   * but the error is still retried. In this case the framework logs the error on a lower level,
+   * since the reconciler already had the chance to handle and log it as needed.
+   */
+  public PostExecutionControl<R> withErrorHandledByReconciler() {
+    this.errorHandledByReconciler = true;
+    return this;
+  }
+
+  public boolean isErrorHandledByReconciler() {
+    return errorHandledByReconciler;
   }
 
   public Optional<R> getUpdatedCustomResource() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcher.java
@@ -266,7 +266,12 @@ class ReconciliationDispatcher<P extends HasMetadata> {
       errorStatusUpdateControl.getScheduleDelay().ifPresent(postExecutionControl::withReSchedule);
       return postExecutionControl;
     }
-    throw e;
+    // The reconciler handled the error via updateErrorStatus (it did not return
+    // defaultErrorProcessing()) but still wants the error to be retried. The retry (and its
+    // backoff) is kept intact, but since the reconciler already had the chance to handle and log
+    // the error, the framework logs it on a lower level instead of emitting an "uncaught error"
+    // warning.
+    return PostExecutionControl.<P>exceptionDuringExecution(e).withErrorHandledByReconciler();
   }
 
   private PostExecutionControl<P> createPostExecutionControl(

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcherTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ReconciliationDispatcherTest.java
@@ -482,6 +482,40 @@ class ReconciliationDispatcherTest {
   }
 
   @Test
+  void errorHandledByReconcilerMarkedWhenErrorStatusHandledButRetried() {
+    testCustomResource.addFinalizer(DEFAULT_FINALIZER);
+    reconciler.reconcile =
+        (r, c) -> {
+          throw new IllegalStateException("Error Status Test");
+        };
+    reconciler.errorHandler = () -> ErrorStatusUpdateControl.patchStatus(testCustomResource);
+
+    var postExecControl =
+        reconciliationDispatcher.handleExecution(
+            new ExecutionScope(null, null, false, false).setResource(testCustomResource));
+
+    assertThat(postExecControl.exceptionDuringExecution()).isTrue();
+    assertThat(postExecControl.isErrorHandledByReconciler()).isTrue();
+  }
+
+  @Test
+  void errorNotHandledByReconcilerOnDefaultErrorProcessing() {
+    testCustomResource.addFinalizer(DEFAULT_FINALIZER);
+    reconciler.reconcile =
+        (r, c) -> {
+          throw new IllegalStateException("Error Status Test");
+        };
+    reconciler.errorHandler = () -> ErrorStatusUpdateControl.defaultErrorProcessing();
+
+    var postExecControl =
+        reconciliationDispatcher.handleExecution(
+            new ExecutionScope(null, null, false, false).setResource(testCustomResource));
+
+    assertThat(postExecControl.exceptionDuringExecution()).isTrue();
+    assertThat(postExecControl.isErrorHandledByReconciler()).isFalse();
+  }
+
+  @Test
   void errorHandlerCanInstructNoRetryWithUpdate() {
     testCustomResource.addFinalizer(DEFAULT_FINALIZER);
     reconciler.reconcile =


### PR DESCRIPTION
 ### Problem

  When a `Reconciler` throws an exception that it deliberately handles in `updateErrorStatus` and classifies as expected & retryable (e.g. "waiting for a dependency that isn't present yet"), there was no way to keep JOSDK's
  native retry (exponential backoff via `@GradualRetry`) while suppressing or downgrading the `EventProcessor` "Uncaught error during event processing" WARN. Retry and that log were the same code path.

  In `ReconciliationDispatcher.handleErrorStatusHandler`, the `updateErrorStatus` result only avoided re-throwing when `isNoRetry()` was set; any retry-enabled control ended with `throw e`, which became
  `exceptionDuringExecution` and triggered `EventProcessor.handleRetryOnException` — the single method that both schedules the retry and emits the WARN via `retryAwareErrorLogging`.

  The only built-in escape was `withNoRetry()` (also implied by `rescheduleAfter()`), which suppresses the log but **disables native retry**: you lose the `@GradualRetry` exponential backoff and the retry counter. With
  `@GradualRetry(maxAttempts = -1)` this was especially bad: `isLastAttempt()` is never true, so every attempt hit the WARN branch — a continuous stream of WARN + stack trace for an entirely expected condition, on top of
  duplicate logging since the exception was already logged inside `updateErrorStatus`.
  
  ### Change

  When `updateErrorStatus` returns any `ErrorStatusUpdateControl` **other than** `ErrorStatusUpdateControl.defaultErrorProcessing()`, the error is now considered handled by the reconciler. Native retry (including
  `@GradualRetry` backoff and the retry counter) is kept fully intact, but **while retry attempts remain** the framework logs the error on **DEBUG** level instead of emitting the "Uncaught error during event processing" WARN.

  Crucially, this only downgrades transient, still-retrying failures. On the **last retry attempt** — or when **no retry is configured** — the failure is final, so the framework preserves its existing higher-severity WARN/ERROR
  logging. This avoids hiding a non-recoverable error from operators once retries are exhausted.

  Returning `ErrorStatusUpdateControl.defaultErrorProcessing()` preserves the previous behavior in all cases, including the warning. This follows the precedent already in this area, where the status-patch failure path and
  `retryAwareErrorLogging` already do selective, level-aware downgrading.

  ### Behavior matrix

  | `updateErrorStatus` returns | Retry | Framework log (retries remaining) | Framework log (last attempt / no retry) |
  |---|---|---|---|
  | `defaultErrorProcessing()` | yes | WARN (unchanged) | ERROR (unchanged) |
  | `patchStatus()` / `noStatusUpdate()` (retry enabled) | yes, backoff intact | **DEBUG** (new) | WARN/ERROR (unchanged) |
  | `withNoRetry()` / `rescheduleAfter()` | no | — | (unchanged) |

  ### Implementation

  - `PostExecutionControl` carries a new `errorHandledByReconciler` flag.
  - `ReconciliationDispatcher` marks the exception control as handled instead of rethrowing when a non-default control still wants retry.
  - `EventProcessor.retryAwareErrorLogging` downgrades to DEBUG only when `errorHandledByReconciler && !retry.isLastAttempt()`; otherwise it falls through to the existing WARN/ERROR logic.
  - `EventProcessor.logErrorIfNoRetryConfigured` keeps logging at ERROR regardless of the flag, since without retry every failure is final.

  ### Notes for reviewers

  This makes the downgrade **implicit** for any non-default control, rather than an explicit opt-in (e.g. `withoutDefaultErrorLogging()`). It's the simplest approach and matches the proposal in the issue, but it does change the
  log level for existing users who return `patchStatus()` with retry enabled (while retries remain). If we'd prefer an explicit opt-in method on `ErrorStatusUpdateControl`, that's a small addition on top of this.

  ### Docs

  Updated `error-handling-retries.md` to describe the new behavior, including the last-attempt / no-retry exception.