### PR TITLE
docs: blog post 5.5 wording

### DIFF
--- a/docs/content/en/blog/releases/v5-5-release.md
+++ b/docs/content/en/blog/releases/v5-5-release.md
@@ -58,7 +58,7 @@ operation type; when one does not fit, supply your own via `Options.matchAndFilt
 > locking; otherwise a concurrent external update inside the filter window may be missed until the
 > next resync.
 
-### More correct own-event filtering (no-op update edge case)
+### Correct own-event filtering (no-op update edge case)
 
 The read-cache-after-write own-event filter has been reworked to fix an edge case where a legitimate
 external change could be filtered out together with a controller's own **no-op** update — for


### PR DESCRIPTION
Minor change from "more correct" ti "correct". Which is the correct phrase.

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
