### PR TITLE
test: verify Kotlin interop with a unit test and a Kotlin sample operator E2E test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -25,6 +25,7 @@ jobs:
           - "sample-operators/webpage"
           - "sample-operators/leader-election"
           - "sample-operators/operations"
+          - "sample-operators/kotlin-operator"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/operator-framework-core/pom.xml
+++ b/operator-framework-core/pom.xml
@@ -30,6 +30,11 @@
   <name>Operator SDK - Framework - Core</name>
   <description>Core framework for implementing Kubernetes operators</description>
 
+  <properties>
+    <!-- Used only for test sources, to verify that the framework works properly with Kotlin. -->
+    <kotlin.version>2.4.10</kotlin.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.github.java-diff-utils</groupId>
@@ -101,6 +106,13 @@
       <artifactId>kube-api-test-client-inject</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- Test-only, used to verify JOSDK works properly when used from Kotlin. -->
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -144,6 +156,37 @@
             <goals>
               <goal>filter-sources</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!--
+          Compiles the Kotlin test sources under src/test/kotlin, used only to verify that JOSDK
+          works properly when used from Kotlin (see https://github.com/operator-framework/java-operator-sdk/issues/2967).
+          Bound to process-test-sources so the compiled Kotlin classes are on the classpath before
+          the regular Java test sources are compiled.
+        -->
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <configuration>
+          <jvmTarget>${java.version}</jvmTarget>
+        </configuration>
+        <executions>
+          <execution>
+            <id>kotlin-test-compile</id>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+            <phase>process-test-sources</phase>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                <!-- Not compiled by Kotlin, only needed so the Kotlin sources can reference the
+                     existing Java test classes (e.g. TestCustomResource). -->
+                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+              </sourceDirs>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/operator-framework-core/src/test/kotlin/io/javaoperatorsdk/operator/processing/dependent/workflow/KotlinCheckedExceptionDependentResourceTest.kt
+++ b/operator-framework-core/src/test/kotlin/io/javaoperatorsdk/operator/processing/dependent/workflow/KotlinCheckedExceptionDependentResourceTest.kt
@@ -90,4 +90,5 @@ class KotlinCheckedExceptionDependentResourceTest {
     } finally {
       executorService.shutdownNow()
     }
+  }
 }

--- a/operator-framework-core/src/test/kotlin/io/javaoperatorsdk/operator/processing/dependent/workflow/KotlinCheckedExceptionDependentResourceTest.kt
+++ b/operator-framework-core/src/test/kotlin/io/javaoperatorsdk/operator/processing/dependent/workflow/KotlinCheckedExceptionDependentResourceTest.kt
@@ -69,20 +69,25 @@ class KotlinCheckedExceptionDependentResourceTest {
 
     @Suppress("UNCHECKED_CAST")
     val context = mock(Context::class.java) as Context<TestCustomResource>
-    `when`(context.managedWorkflowAndDependentResourceContext())
-        .thenReturn(mock(ManagedWorkflowAndDependentResourceContext::class.java))
-    `when`(context.workflowExecutorService).thenReturn(Executors.newCachedThreadPool())
-    @Suppress("UNCHECKED_CAST")
-    `when`(context.eventSourceRetriever())
-        .thenReturn(mock(EventSourceRetriever::class.java) as EventSourceRetriever<TestCustomResource>)
+    val executorService = Executors.newSingleThreadExecutor()
+    try {
+      `when`(context.managedWorkflowAndDependentResourceContext())
+          .thenReturn(mock(ManagedWorkflowAndDependentResourceContext::class.java))
+      `when`(context.workflowExecutorService).thenReturn(executorService)
+      @Suppress("UNCHECKED_CAST")
+      `when`(context.eventSourceRetriever())
+          .thenReturn(mock(EventSourceRetriever::class.java) as EventSourceRetriever<TestCustomResource>)
 
-    val result = workflow.reconcile(TestCustomResource(), context)
+      val result = workflow.reconcile(TestCustomResource(), context)
 
-    // the checked exception was caught by the workflow executor, not left uncaught, so it is
-    // reported as an error for the dependent resource, which is what allows JOSDK to retry the
-    // reconciliation.
-    assertThat(result.erroredDependents).containsOnlyKeys(dependentResource)
-    assertThat(result.erroredDependents[dependentResource]).isInstanceOf(CheckedException::class.java)
-    assertThrows<AggregatedOperatorException> { result.throwAggregateExceptionIfErrorsPresent() }
-  }
+      // the checked exception was caught by the workflow executor, not left uncaught, so it is
+      // reported as an error for the dependent resource, which is what allows JOSDK to retry the
+      // reconciliation.
+      assertThat(result.erroredDependents).containsOnlyKeys(dependentResource)
+      assertThat(result.erroredDependents[dependentResource])
+          .isInstanceOf(CheckedException::class.java)
+      assertThrows<AggregatedOperatorException> { result.throwAggregateExceptionIfErrorsPresent() }
+    } finally {
+      executorService.shutdownNow()
+    }
 }

--- a/operator-framework-core/src/test/kotlin/io/javaoperatorsdk/operator/processing/dependent/workflow/KotlinCheckedExceptionDependentResourceTest.kt
+++ b/operator-framework-core/src/test/kotlin/io/javaoperatorsdk/operator/processing/dependent/workflow/KotlinCheckedExceptionDependentResourceTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.processing.dependent.workflow
+
+import io.javaoperatorsdk.operator.AggregatedOperatorException
+import io.javaoperatorsdk.operator.api.reconciler.Context
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource
+import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult
+import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedWorkflowAndDependentResourceContext
+import io.javaoperatorsdk.operator.processing.event.EventSourceRetriever
+import io.javaoperatorsdk.operator.sample.simple.TestCustomResource
+import java.util.concurrent.Executors
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+/**
+ * Smoke test verifying that JOSDK works properly when used from Kotlin.
+ *
+ * Unlike Java, Kotlin does not distinguish between checked and unchecked exceptions, so a Kotlin
+ * [DependentResource] can throw a plain [java.lang.Exception] from `reconcile` without declaring
+ * it, even though the Java `DependentResource.reconcile` method does not declare `throws
+ * Exception`. Before https://github.com/operator-framework/java-operator-sdk/pull/2965 such an
+ * exception was not caught by [NodeExecutor], since it only handled [RuntimeException], so it
+ * would not have been recorded as an error and retries would not have been triggered. This test
+ * makes sure such an exception is properly caught and reported, see
+ * https://github.com/operator-framework/java-operator-sdk/issues/2967.
+ */
+class KotlinCheckedExceptionDependentResourceTest {
+
+  private class CheckedException(message: String) : Exception(message)
+
+  private class ThrowingDependentResource :
+      DependentResource<String, TestCustomResource> {
+    override fun reconcile(
+        primary: TestCustomResource,
+        context: Context<TestCustomResource>
+    ): ReconcileResult<String> {
+      throw CheckedException("checked exception thrown from Kotlin")
+    }
+
+    override fun resourceType(): Class<String> = String::class.java
+  }
+
+  @Test
+  fun checkedExceptionThrownFromKotlinDependentResourceTriggersRetry() {
+    val dependentResource = ThrowingDependentResource()
+
+    val workflow =
+        WorkflowBuilder<TestCustomResource>()
+            .addDependentResource(dependentResource)
+            .withThrowExceptionFurther(false)
+            .build()
+
+    @Suppress("UNCHECKED_CAST")
+    val context = mock(Context::class.java) as Context<TestCustomResource>
+    `when`(context.managedWorkflowAndDependentResourceContext())
+        .thenReturn(mock(ManagedWorkflowAndDependentResourceContext::class.java))
+    `when`(context.workflowExecutorService).thenReturn(Executors.newCachedThreadPool())
+    @Suppress("UNCHECKED_CAST")
+    `when`(context.eventSourceRetriever())
+        .thenReturn(mock(EventSourceRetriever::class.java) as EventSourceRetriever<TestCustomResource>)
+
+    val result = workflow.reconcile(TestCustomResource(), context)
+
+    // the checked exception was caught by the workflow executor, not left uncaught, so it is
+    // reported as an error for the dependent resource, which is what allows JOSDK to retry the
+    // reconciliation.
+    assertThat(result.erroredDependents).containsOnlyKeys(dependentResource)
+    assertThat(result.erroredDependents[dependentResource]).isInstanceOf(CheckedException::class.java)
+    assertThrows<AggregatedOperatorException> { result.throwAggregateExceptionIfErrorsPresent() }
+  }
+}

--- a/sample-operators/kotlin-operator/README.md
+++ b/sample-operators/kotlin-operator/README.md
@@ -1,0 +1,15 @@
+# Kotlin Operator Sample
+
+This module is a minimalist end-to-end test verifying that JOSDK works properly when both the
+custom resource and the reconciler are implemented in Kotlin rather than Java.
+
+The `ConfigMapCopyReconciler` reads `spec.message` from a `ConfigMapCopy` custom resource and
+copies it into a `ConfigMap`. This exercises:
+
+- deserialization of the custom resource from the Kubernetes API via the fabric8 client,
+- a Kotlin-implemented `Reconciler`, and
+- the rest of the reconciliation runtime (event sources, status updates, owner references).
+
+See [`KotlinCheckedExceptionDependentResourceTest`](../../operator-framework-core/src/test/kotlin/io/javaoperatorsdk/operator/processing/dependent/workflow/KotlinCheckedExceptionDependentResourceTest.kt)
+for a narrower unit-level test covering checked-exception handling specifically (see
+[#2967](https://github.com/operator-framework/java-operator-sdk/issues/2967)).

--- a/sample-operators/kotlin-operator/k8s/operator.yaml
+++ b/sample-operators/kotlin-operator/k8s/operator.yaml
@@ -1,0 +1,71 @@
+#
+# Copyright Java Operator SDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kotlin-operator
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kotlin-operator
+spec:
+  serviceAccountName: kotlin-operator
+  containers:
+    - name: operator
+      image: kotlin-sample-operator
+      imagePullPolicy: Never
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kotlin-operator
+subjects:
+  - kind: ServiceAccount
+    name: kotlin-operator
+roleRef:
+  kind: ClusterRole
+  name: kotlin-operator
+  apiGroup: ""
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kotlin-operator
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - "sample.javaoperatorsdk"
+    resources:
+      - configmapcopies
+      - configmapcopies/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - '*'

--- a/sample-operators/kotlin-operator/k8s/operator.yaml
+++ b/sample-operators/kotlin-operator/k8s/operator.yaml
@@ -42,7 +42,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: kotlin-operator
-  apiGroup: ""
+  apiGroup: rbac.authorization.k8s.io
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/sample-operators/kotlin-operator/pom.xml
+++ b/sample-operators/kotlin-operator/pom.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Java Operator SDK Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.javaoperatorsdk</groupId>
+    <artifactId>sample-operators</artifactId>
+    <version>5.5.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>sample-kotlin-operator</artifactId>
+  <packaging>jar</packaging>
+  <name>Operator SDK - Samples - Kotlin Operator</name>
+  <description>Minimalist operator implemented in Kotlin, copying a value from a custom
+    resource's spec into a ConfigMap, verifying JOSDK works properly end-to-end when used from
+    Kotlin</description>
+
+  <properties>
+    <kotlin.version>2.4.10</kotlin.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.javaoperatorsdk</groupId>
+        <artifactId>operator-framework-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.javaoperatorsdk</groupId>
+      <artifactId>operator-framework</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.javaoperatorsdk</groupId>
+      <artifactId>operator-framework-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <!-- Compiles the Kotlin sources under src/main/kotlin and src/test/kotlin. -->
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <configuration>
+          <jvmTarget>${java.version}</jvmTarget>
+        </configuration>
+        <executions>
+          <execution>
+            <id>kotlin-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>process-sources</phase>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+              </sourceDirs>
+            </configuration>
+          </execution>
+          <execution>
+            <id>kotlin-test-compile</id>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+            <phase>process-test-sources</phase>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+              </sourceDirs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- Generates the CRD from the annotated Kotlin custom resource class, used by
+             ClusterDeployedOperatorExtension in remote E2E mode. -->
+        <groupId>io.fabric8</groupId>
+        <artifactId>crd-generator-maven-plugin</artifactId>
+        <version>${fabric8-client.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <rerunFailingTestsCount>0</rerunFailingTestsCount>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>${jib-maven-plugin.version}</version>
+        <configuration>
+          <from>
+            <image>gcr.io/distroless/java17-debian11</image>
+          </from>
+          <to>
+            <image>kotlin-sample-operator</image>
+          </to>
+          <container>
+            <mainClass>io.javaoperatorsdk.operator.sample.ConfigMapCopyOperatorKt</mainClass>
+          </container>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/sample-operators/kotlin-operator/pom.xml
+++ b/sample-operators/kotlin-operator/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <scope>compile</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.javaoperatorsdk</groupId>

--- a/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopy.kt
+++ b/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopy.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.sample
+
+import io.fabric8.kubernetes.api.model.Namespaced
+import io.fabric8.kubernetes.client.CustomResource
+import io.fabric8.kubernetes.model.annotation.Group
+import io.fabric8.kubernetes.model.annotation.Version
+
+@Group("sample.javaoperatorsdk")
+@Version("v1")
+class ConfigMapCopy : CustomResource<ConfigMapCopySpec, ConfigMapCopyStatus>(), Namespaced

--- a/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyOperator.kt
+++ b/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyOperator.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.sample
+
+import io.javaoperatorsdk.operator.Operator
+
+fun main() {
+  val operator = Operator()
+  operator.register(ConfigMapCopyReconciler())
+  operator.start()
+}

--- a/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyReconciler.kt
+++ b/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyReconciler.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.sample
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder
+import io.javaoperatorsdk.operator.api.reconciler.Context
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl
+
+/**
+ * Minimalist reconciler verifying that JOSDK works properly end-to-end when both the custom
+ * resource and the reconciler are implemented in Kotlin: it copies `spec.message` into a
+ * `ConfigMap`, exercising deserialization of the custom resource by the fabric8 client as well as
+ * the rest of the reconciliation runtime.
+ */
+@ControllerConfiguration
+class ConfigMapCopyReconciler : Reconciler<ConfigMapCopy> {
+
+  companion object {
+    const val MESSAGE_KEY = "message"
+
+    fun configMapName(resource: ConfigMapCopy): String = resource.metadata.name + "-config"
+  }
+
+  override fun reconcile(
+      resource: ConfigMapCopy,
+      context: Context<ConfigMapCopy>
+  ): UpdateControl<ConfigMapCopy> {
+    val data: Map<String, String> = mapOf(MESSAGE_KEY to resource.spec.message)
+    val configMap =
+        ConfigMapBuilder()
+            .withMetadata(
+                ObjectMetaBuilder()
+                    .withName(configMapName(resource))
+                    .withNamespace(resource.metadata.namespace)
+                    .build())
+            .withData<String, String>(data)
+            .build()
+    configMap.addOwnerReference(resource)
+
+    context.client.resource(configMap).serverSideApply()
+
+    resource.status = ConfigMapCopyStatus()
+    resource.status.configMapName = configMap.metadata.name
+    resource.status.observedMessage = resource.spec.message
+
+    return UpdateControl.patchStatus(resource)
+  }
+}

--- a/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopySpec.kt
+++ b/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopySpec.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.sample
+
+class ConfigMapCopySpec {
+  var message: String = ""
+}

--- a/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyStatus.kt
+++ b/sample-operators/kotlin-operator/src/main/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyStatus.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.sample
+
+class ConfigMapCopyStatus {
+  var configMapName: String? = null
+  var observedMessage: String? = null
+}

--- a/sample-operators/kotlin-operator/src/main/resources/log4j2.xml
+++ b/sample-operators/kotlin-operator/src/main/resources/log4j2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Java Operator SDK Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %threadId %-30c{1.} [%-5level] %msg p:[%X{resource.name}:%X{resource.namespace}:%X{resource.resourceVersion}] e:[%X{eventsource.name}:%X{eventsource.event.action}:%X{eventsource.event.resource.name}:%X{eventsource.event.resource.namespace}:%X{eventsource.event.resource.resourceVersion}] %n%throwable"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/sample-operators/kotlin-operator/src/test/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyE2E.kt
+++ b/sample-operators/kotlin-operator/src/test/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyE2E.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.sample
+
+import io.fabric8.kubernetes.api.model.ConfigMap
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder
+import io.fabric8.kubernetes.client.KubernetesClientBuilder
+import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension
+import io.javaoperatorsdk.operator.junit.ClusterDeployedOperatorExtension
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension
+import java.io.FileInputStream
+import java.time.Duration
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Dual-mode (local and remote) E2E test exercising [ConfigMapCopyReconciler]: creates a
+ * [ConfigMapCopy] resource, asserts a [ConfigMap] is created with the message copied from spec,
+ * updates the message, and verifies the [ConfigMap] is garbage collected on deletion via the
+ * owner reference.
+ */
+class ConfigMapCopyE2E {
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(ConfigMapCopyE2E::class.java)
+
+    const val TEST_RESOURCE_NAME = "test-config-map-copy"
+    const val INITIAL_MESSAGE = "hello from kotlin"
+    const val UPDATED_MESSAGE = "updated from kotlin"
+    const val GARBAGE_COLLECTION_TIMEOUT_SECONDS = 90L
+
+    private val client = KubernetesClientBuilder().build()
+
+    fun isLocal(): Boolean {
+      val deployment = System.getProperty("test.deployment")
+      val remote = deployment != null && deployment == "remote"
+      log.info("Running the operator " + (if (remote) "remotely" else "locally"))
+      return !remote
+    }
+  }
+
+  @RegisterExtension
+  val operator: AbstractOperatorExtension =
+      if (isLocal())
+          LocallyRunOperatorExtension.builder().withReconciler(ConfigMapCopyReconciler()).build()
+      else
+          ClusterDeployedOperatorExtension.builder()
+              .withOperatorDeployment(client.load(FileInputStream("k8s/operator.yaml")).items())
+              .build()
+
+  @Test
+  fun copiesMessageFromSpecIntoConfigMap() {
+    val resource = operator.create(testResource(INITIAL_MESSAGE))
+
+    await().untilAsserted {
+      val updated = operator.get(ConfigMapCopy::class.java, TEST_RESOURCE_NAME)
+      assertThat(updated.status).isNotNull()
+      assertThat(updated.status.observedMessage).isEqualTo(INITIAL_MESSAGE)
+
+      val configMap =
+          operator.get(ConfigMap::class.java, ConfigMapCopyReconciler.configMapName(resource))
+      assertThat(configMap).isNotNull()
+      assertThat(configMap.data[ConfigMapCopyReconciler.MESSAGE_KEY]).isEqualTo(INITIAL_MESSAGE)
+    }
+
+    val toUpdate = operator.get(ConfigMapCopy::class.java, TEST_RESOURCE_NAME)
+    toUpdate.spec.message = UPDATED_MESSAGE
+    operator.replace(toUpdate)
+
+    await().untilAsserted {
+      val configMap =
+          operator.get(ConfigMap::class.java, ConfigMapCopyReconciler.configMapName(resource))
+      assertThat(configMap.data[ConfigMapCopyReconciler.MESSAGE_KEY]).isEqualTo(UPDATED_MESSAGE)
+    }
+
+    operator.delete(toUpdate)
+
+    await()
+        .atMost(Duration.ofSeconds(GARBAGE_COLLECTION_TIMEOUT_SECONDS))
+        .untilAsserted {
+          assertThat(
+                  operator.get(ConfigMap::class.java, ConfigMapCopyReconciler.configMapName(resource)))
+              .isNull()
+        }
+  }
+
+  private fun testResource(message: String): ConfigMapCopy {
+    val resource = ConfigMapCopy()
+    resource.metadata =
+        ObjectMetaBuilder().withName(TEST_RESOURCE_NAME).withNamespace(operator.namespace).build()
+    resource.spec = ConfigMapCopySpec().apply { this.message = message }
+    return resource
+  }
+}

--- a/sample-operators/kotlin-operator/src/test/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyE2E.kt
+++ b/sample-operators/kotlin-operator/src/test/kotlin/io/javaoperatorsdk/operator/sample/ConfigMapCopyE2E.kt
@@ -62,7 +62,8 @@ class ConfigMapCopyE2E {
           LocallyRunOperatorExtension.builder().withReconciler(ConfigMapCopyReconciler()).build()
       else
           ClusterDeployedOperatorExtension.builder()
-              .withOperatorDeployment(client.load(FileInputStream("k8s/operator.yaml")).items())
+              .withOperatorDeployment(
+                  FileInputStream("k8s/operator.yaml").use { client.load(it).items() })
               .build()
 
   @Test

--- a/sample-operators/kotlin-operator/src/test/resources/log4j2.xml
+++ b/sample-operators/kotlin-operator/src/test/resources/log4j2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Java Operator SDK Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%style{%d}{yellow} %style{%-30c{1.}}{cyan} %highlight{[%-5level] %msg%n%throwable}{INFO=white}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/sample-operators/pom.xml
+++ b/sample-operators/pom.xml
@@ -36,5 +36,6 @@
     <module>leader-election</module>
     <module>controller-namespace-deletion</module>
     <module>operations</module>
+    <module>kotlin-operator</module>
   </modules>
 </project>


### PR DESCRIPTION
Closes #2967

## What this does

Adds Kotlin interop test coverage in two forms, per review discussion:

1. A unit-level smoke test in `operator-framework-core` verifying that JOSDK behaves correctly when a `DependentResource` is implemented in Kotlin.
2. A new sample module, `sample-operators/kotlin-operator`, with a minimalist Kotlin operator and a full dual-mode (local + remote-deployed) E2E test, mirroring the other samples.

Kotlin has no concept of checked vs. unchecked exceptions, so Kotlin code can throw a plain `Exception` from an overridden method (e.g. `DependentResource#reconcile`) without declaring it — even though the Java-declared method signature doesn't include `throws Exception`. Before #2965, `NodeExecutor` only caught `RuntimeException`, so such an exception thrown from Kotlin would silently bypass the workflow's error handling and not trigger a retry.

### 1. Unit-level smoke test (`operator-framework-core`)

The new test (`KotlinCheckedExceptionDependentResourceTest.kt`):
- Defines a Kotlin `DependentResource` whose `reconcile` throws a custom checked `Exception`.
- Runs it through the real `Workflow`/`WorkflowReconcileExecutor`/`NodeExecutor` (no mocked cluster needed).
- Asserts the exception is captured in `WorkflowReconcileResult#getErroredDependents()` and that `throwAggregateExceptionIfErrorsPresent()` throws `AggregatedOperatorException`, confirming a retry would be triggered.

I verified this test actually exercises the fix: temporarily reverting `NodeExecutor`'s `catch (Exception e)` back to `catch (RuntimeException e)` (the pre-#2965 behavior) makes the test fail, since the checked exception is then silently swallowed and `getErroredDependents()` stays empty.

Adds `kotlin-maven-plugin` (test scope only, `2.4.10`) to `operator-framework-core/pom.xml`, compiling sources under `src/test/kotlin`. No other module is affected, and no Kotlin dependency is added to the main/runtime classpath.

### 2. New sample: `sample-operators/kotlin-operator`

Per review feedback, added a full sample operator implemented entirely in Kotlin (CR, spec, status, reconciler, `main`), to validate more than just the checked-exception path:

- `ConfigMapCopyReconciler` copies `spec.message` from a `ConfigMapCopy` custom resource into a `ConfigMap`, exercising custom resource deserialization via the fabric8 client and the full reconciliation runtime (not just exception handling).
- `ConfigMapCopyE2E` is a dual-mode E2E test, following the same pattern as the other samples: `LocallyRunOperatorExtension` for local mode, `ClusterDeployedOperatorExtension` (+ a real `Pod` deployment described in `k8s/operator.yaml`, built via `jib-maven-plugin`) for remote mode.
- Wired into `sample-operators/pom.xml` and the `end-to-end-tests` matrix in `.github/workflows/e2e-test.yml`, so it runs against a real (Minikube) cluster in CI like the other samples.

## Relation to #2965

#2965 fixed `NodeExecutor`, `AbstractWorkflowExecutor`, and `PollingEventSource` to catch `Exception` instead of `RuntimeException` (with `// Exception is required because of Kotlin` comments already in place), and opened #2967 as a follow-up to add tests validating this behavior with actual Kotlin code. I also grepped the codebase for any remaining `catch (RuntimeException` in main sources and found none left to fix.

## Test plan
- [x] `./mvnw -pl operator-framework-core -am test` — unit test passes; verified it fails against the pre-#2965 `catch (RuntimeException)` behavior and passes against current `catch (Exception)` behavior
- [x] `./mvnw -pl sample-operators/kotlin-operator -am test-compile` — new sample module compiles, including CRD generation from the Kotlin-annotated custom resource
- [ ] `sample-operators/kotlin-operator` E2E test against a real cluster — will be exercised by the `end-to-end-tests` CI job (no local cluster available to verify manually in this environment)
