### PR TITLE
fix: NPE in external resource caching event source when only a generic filter is set

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
@@ -163,7 +163,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     if (onAddFilter != null || genericFilter != null) {
       var anyAddAccepted =
           addedResources.values().stream()
-              .anyMatch(r -> acceptedByGenericFiler(r) && acceptedByOnAddFilter(r));
+              .anyMatch(r -> acceptedByGenericFilter(r) && acceptedByOnAddFilter(r));
       if (anyAddAccepted) {
         return true;
       }
@@ -176,7 +176,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     if (onDeleteFilter != null || genericFilter != null) {
       var anyDeleteAccepted =
           deletedResource.values().stream()
-              .anyMatch(r -> acceptedByGenericFiler(r) && acceptedByOnDeleteFilter(r));
+              .anyMatch(r -> acceptedByGenericFilter(r) && acceptedByOnDeleteFilter(r));
       if (anyDeleteAccepted) {
         return true;
       }
@@ -196,7 +196,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
           .anyMatch(
               entry -> {
                 var newResource = newResourcesMap.get(entry.getKey());
-                return acceptedByGenericFiler(newResource)
+                return acceptedByGenericFilter(newResource)
                     && acceptedByOnUpdateFilter(newResource, entry.getValue());
               });
     } else return !possibleUpdatedResources.isEmpty();
@@ -214,7 +214,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     return onUpdateFilter == null || onUpdateFilter.accept(newResource, oldResource);
   }
 
-  private boolean acceptedByGenericFiler(R resource) {
+  private boolean acceptedByGenericFilter(R resource) {
     return genericFilter == null || genericFilter.accept(resource);
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
@@ -163,7 +163,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     if (onAddFilter != null || genericFilter != null) {
       var anyAddAccepted =
           addedResources.values().stream()
-              .anyMatch(r -> acceptedByGenericFiler(r) && onAddFilter.accept(r));
+              .anyMatch(r -> acceptedByGenericFiler(r) && acceptedByOnAddFilter(r));
       if (anyAddAccepted) {
         return true;
       }
@@ -176,7 +176,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     if (onDeleteFilter != null || genericFilter != null) {
       var anyDeleteAccepted =
           deletedResource.values().stream()
-              .anyMatch(r -> acceptedByGenericFiler(r) && onDeleteFilter.accept(r, false));
+              .anyMatch(r -> acceptedByGenericFiler(r) && acceptedByOnDeleteFilter(r));
       if (anyDeleteAccepted) {
         return true;
       }
@@ -197,9 +197,21 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
               entry -> {
                 var newResource = newResourcesMap.get(entry.getKey());
                 return acceptedByGenericFiler(newResource)
-                    && onUpdateFilter.accept(newResource, entry.getValue());
+                    && acceptedByOnUpdateFilter(newResource, entry.getValue());
               });
     } else return !possibleUpdatedResources.isEmpty();
+  }
+
+  private boolean acceptedByOnAddFilter(R resource) {
+    return onAddFilter == null || onAddFilter.accept(resource);
+  }
+
+  private boolean acceptedByOnDeleteFilter(R resource) {
+    return onDeleteFilter == null || onDeleteFilter.accept(resource, false);
+  }
+
+  private boolean acceptedByOnUpdateFilter(R newResource, R oldResource) {
+    return onUpdateFilter == null || onUpdateFilter.accept(newResource, oldResource);
   }
 
   private boolean acceptedByGenericFiler(R resource) {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSourceTest.java
@@ -211,6 +211,43 @@ class ExternalResourceCachingEventSourceTest
     verify(eventHandler, times(0)).handleEvent(any());
   }
 
+  @Test
+  void onlyGenericFilterSetDoesNotFailOnAdd() {
+    var eventSource = new TestExternalCachingEventSource();
+    eventSource.setGenericFilter(res -> true);
+    setUpSource(eventSource);
+
+    source.handleResources(primaryID1(), Set.of(testResource1()));
+
+    verify(eventHandler, times(1)).handleEvent(any());
+  }
+
+  @Test
+  void onlyGenericFilterSetDoesNotFailOnDelete() {
+    var eventSource = new TestExternalCachingEventSource();
+    eventSource.setGenericFilter(res -> true);
+    setUpSource(eventSource);
+
+    source.handleResources(primaryID1(), Set.of(testResource1()));
+    source.handleResources(primaryID1(), Set.of());
+
+    verify(eventHandler, times(2)).handleEvent(any());
+  }
+
+  @Test
+  void onlyGenericFilterSetDoesNotFailOnUpdate() {
+    var eventSource = new TestExternalCachingEventSource();
+    eventSource.setGenericFilter(res -> true);
+    setUpSource(eventSource);
+
+    source.handleResources(primaryID1(), Set.of(testResource1()));
+    var changed = testResource1();
+    changed.setValue("changedValue");
+    source.handleResources(primaryID1(), Set.of(changed));
+
+    verify(eventHandler, times(2)).handleEvent(any());
+  }
+
   public static class TestExternalCachingEventSource
       extends ExternalResourceCachingEventSource<SampleExternalResource, HasMetadata, String> {
     public TestExternalCachingEventSource() {


### PR DESCRIPTION
`acceptedByFiler` guards each of its three filter branches with
`onXFilter != null || genericFilter != null`, but the branch body
dereferences `onXFilter` unconditionally:

    if (onAddFilter != null || genericFilter != null) {
      ... .anyMatch(r -> acceptedByGenericFiler(r) && onAddFilter.accept(r));

So configuring only a generic filter via `setGenericFilter(...)` throws a
NullPointerException as soon as a resource is added, deleted or updated.
All three branches (add / delete / update) are affected, which means
`PollingEventSource`, `PerResourcePollingEventSource` and
`CachingInboundEventSource` all break when used with a generic filter
only.

The existing `genericFilteringEvents` test missed this because it uses a
filter that returns `false`: `&&` short-circuits before the null
dereference. Only a generic filter that accepts a resource reaches the
NPE.

Each filter check is now null-safe (an absent filter accepts), which
preserves the previous behaviour whenever the specific filter is set.

Adds three regression tests, one per branch; they fail with
NullPointerException without this change.

Part of #3517