### PR TITLE
fix: NPE in handleRecentResourceUpdate for an unknown secondary resource

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
@@ -226,7 +226,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     if (actualValues != null) {
       var resourceId = resourceIDMapper.idFor(resource);
       R actualResource = actualValues.get(resourceId);
-      if (actualResource.equals(previousVersionOfResource)) {
+      if (actualResource != null && actualResource.equals(previousVersionOfResource)) {
         actualValues.put(resourceId, resource);
       }
     }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSourceTest.java
@@ -211,6 +211,17 @@ class ExternalResourceCachingEventSourceTest
     verify(eventHandler, times(0)).handleEvent(any());
   }
 
+  @Test
+  void recentResourceUpdateIsIgnoredForUnknownSecondaryResource() {
+    source.handleResources(primaryID1(), Set.of(testResource1()));
+
+    // testResource2 has a different id, so it is not present in the cache for primaryID1
+    var unknown = testResource2();
+    source.handleRecentResourceUpdate(primaryID1(), unknown, unknown);
+
+    assertThat(source.getSecondaryResources(primaryID1())).containsExactly(testResource1());
+  }
+
   public static class TestExternalCachingEventSource
       extends ExternalResourceCachingEventSource<SampleExternalResource, HasMetadata, String> {
     public TestExternalCachingEventSource() {


### PR DESCRIPTION
`ExternalResourceCachingEventSource.handleRecentResourceUpdate` checks
that the primary has an entry in the cache, but then dereferences the
per-secondary lookup without checking it:

    R actualResource = actualValues.get(resourceId);
    if (actualResource.equals(previousVersionOfResource)) {

`actualValues.get(resourceId)` returns null whenever the primary has a
cache entry but that particular secondary id is not in it, which throws a
NullPointerException. This is reachable from
`AbstractEventSourceHolderDependentResource.onUpdated` for any
`RecentOperationCacheFiller` event source, e.g. after an update whose
resource id is not the one currently cached for that primary.

Skips the cache update when the resource is not tracked, which matches
the intent of the surrounding "only overwrite if we still hold the
version the caller saw" check.

Adds a regression test that fails with NullPointerException without this
change.

Part of #3517