### PR TITLE
fix: honour bulk dependent resource capabilities during reconciliation

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractDependentResource.java
@@ -85,7 +85,7 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
   protected ReconcileResult<R> reconcile(P primary, R actualResource, Context<P> context) {
     if (creatable() || updatable()) {
       if (actualResource == null) {
-        if (creatable) {
+        if (creatable()) {
           var desired = getOrComputeDesired(context);
           throwIfNull(desired, primary, "Desired");
           logForOperation("Creating", primary, desired);
@@ -244,12 +244,12 @@ public abstract class AbstractDependentResource<R, P extends HasMetadata>
   }
 
   protected boolean isCreatable() {
-    return creatable;
+    return creatable();
   }
 
   @SuppressWarnings("unused")
   protected boolean isUpdatable() {
-    return updatable;
+    return updatable();
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/BulkDependentResourceReconciler.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/BulkDependentResourceReconciler.java
@@ -148,12 +148,12 @@ class BulkDependentResourceReconciler<R, P extends HasMetadata, ID>
     }
 
     @Override
-    protected boolean isCreatable() {
+    protected boolean creatable() {
       return bulkDependentResource instanceof Creator<?, ?>;
     }
 
     @Override
-    protected boolean isUpdatable() {
+    protected boolean updatable() {
       return bulkDependentResource instanceof Updater<?, ?>;
     }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/BulkDependentResourceCapabilitiesTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/BulkDependentResourceCapabilitiesTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.processing.dependent;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult.Operation;
+import io.javaoperatorsdk.operator.processing.dependent.Matcher.Result;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * A {@link BulkDependentResource} does not have to implement every one of {@link Creator}, {@link
+ * Updater} and {@link Deleter}. The capabilities of the bulk resource itself must therefore be
+ * honoured, not those of the internal per-item wrapper (which implements all three).
+ */
+@SuppressWarnings("unchecked")
+class BulkDependentResourceCapabilitiesTest {
+
+  private static final ConfigMap PRIMARY =
+      new ConfigMapBuilder().withNewMetadata().withName("primary").endMetadata().build();
+
+  @Test
+  void doesNotAttemptUpdateWhenBulkResourceIsNotUpdater() {
+    var result = new CreateAndDeleteOnlyBulk().reconcile(PRIMARY, mock(Context.class));
+
+    assertThat(result.getSingleOperation()).isEqualTo(Operation.NONE);
+  }
+
+  @Test
+  void doesNotAttemptCreateWhenBulkResourceIsNotCreator() {
+    var result = new DeleteOnlyBulk().reconcile(PRIMARY, mock(Context.class));
+
+    assertThat(result.getResourceOperations()).isEmpty();
+  }
+
+  /** Can be created and deleted, but deliberately is not an {@link Updater}. */
+  private static class CreateAndDeleteOnlyBulk extends BaseBulk
+      implements Creator<ConfigMap, ConfigMap>, Deleter<ConfigMap> {
+
+    @Override
+    public Map<String, ConfigMap> getSecondaryResources(
+        ConfigMap primary, Context<ConfigMap> context) {
+      // an actual resource exists, but differs from the desired one
+      var actual = new LinkedHashMap<String, ConfigMap>();
+      actual.put("a", configMap(Map.of("key", "actual")));
+      return actual;
+    }
+
+    @Override
+    public ConfigMap create(ConfigMap desired, ConfigMap primary, Context<ConfigMap> context) {
+      throw new AssertionError("create must not be called, the resource already exists");
+    }
+  }
+
+  /** Can only be deleted: neither {@link Creator} nor {@link Updater}. */
+  private static class DeleteOnlyBulk extends BaseBulk implements Deleter<ConfigMap> {
+
+    @Override
+    public Map<String, ConfigMap> getSecondaryResources(
+        ConfigMap primary, Context<ConfigMap> context) {
+      return Map.of();
+    }
+  }
+
+  private abstract static class BaseBulk extends AbstractDependentResource<ConfigMap, ConfigMap>
+      implements BulkDependentResource<ConfigMap, ConfigMap, String> {
+
+    @Override
+    public Map<String, ConfigMap> desiredResources(ConfigMap primary, Context<ConfigMap> context) {
+      var desired = new LinkedHashMap<String, ConfigMap>();
+      desired.put("a", configMap(Map.of("key", "desired")));
+      return desired;
+    }
+
+    @Override
+    public void deleteTargetResource(
+        ConfigMap primary, ConfigMap resource, String key, Context<ConfigMap> context) {}
+
+    @Override
+    public Result<ConfigMap> match(
+        ConfigMap actualResource,
+        ConfigMap desired,
+        ConfigMap primary,
+        Context<ConfigMap> context) {
+      return Result.computed(false, desired);
+    }
+
+    @Override
+    public Result<ConfigMap> match(
+        ConfigMap resource, ConfigMap primary, Context<ConfigMap> context) {
+      return Result.computed(false, resource);
+    }
+
+    @Override
+    protected Optional<ConfigMap> selectTargetSecondaryResource(
+        Set<ConfigMap> secondaryResources, ConfigMap primary, Context<ConfigMap> context) {
+      return Optional.empty();
+    }
+
+    @Override
+    protected void onCreated(ConfigMap primary, ConfigMap created, Context<ConfigMap> context) {}
+
+    @Override
+    protected void onUpdated(
+        ConfigMap primary, ConfigMap updated, ConfigMap actual, Context<ConfigMap> context) {}
+
+    @Override
+    public Class<ConfigMap> resourceType() {
+      return ConfigMap.class;
+    }
+  }
+
+  private static ConfigMap configMap(Map<String, String> data) {
+    return new ConfigMapBuilder()
+        .withNewMetadata()
+        .withName("a")
+        .endMetadata()
+        .withData(data)
+        .build();
+  }
+}


### PR DESCRIPTION
A `BulkDependentResource` may implement any subset of `Creator`,
`Updater` and `Deleter`. `BulkDependentResourceInstance`, the internal
per-item wrapper that reuses `AbstractDependentResource`'s reconcile
logic, implements all three and delegates each call to the bulk resource
with an unchecked cast. Its capabilities therefore have to be derived
from the wrapped bulk resource.

0b8d8dd8e introduced the overridable `creatable()` / `updatable()` hooks
for exactly this, but the wiring was never completed:

* `BulkDependentResourceInstance` overrides `isCreatable()` /
  `isUpdatable()`, which `reconcile` never consults, so both overrides
  were dead code.
* the inner create branch of `AbstractDependentResource.reconcile` still
  read the `creatable` field directly instead of calling `creatable()`.

Since the wrapper implements all three interfaces, both fields are always
true, so create and update were attempted regardless of what the bulk
resource actually supports, failing with a ClassCastException in
`BulkDependentResourceInstance.create` / `update`:

    java.lang.ClassCastException: class ...CreateAndDeleteOnlyBulk
      cannot be cast to class ...Updater
      at BulkDependentResourceInstance.update(BulkDependentResourceReconciler.java:115)
      at AbstractDependentResource.handleUpdate(AbstractDependentResource.java:204)

A non-bulk dependent in the same situation just logs "implement Updater
interface to modify it" and skips the operation.

Fixes this by overriding `creatable()` / `updatable()` in the wrapper and
by using `creatable()` in the create branch. `isCreatable()` /
`isUpdatable()` now delegate to `creatable()` / `updatable()` so the two
pairs cannot drift apart again.

Adds regression tests for a create+delete-only and a delete-only bulk
dependent; both fail without this change.

Part of #3517