### PR TITLE
fix: read the external resource cache under the event source monitor

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
@@ -250,12 +250,23 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
   }
 
   public Set<R> getSecondaryResources(ResourceID primaryID) {
+    return cachedResourcesFor(primaryID);
+  }
+
+  /**
+   * Snapshot of the currently cached secondary resources for the target primary. The per-primary
+   * maps held in the cache are not thread safe and are mutated while holding this object's monitor,
+   * so they must not be read outside of it.
+   *
+   * @param primaryID id of the primary resource
+   * @return a copy of the cached secondary resources, empty if none are cached
+   */
+  protected synchronized Set<R> cachedResourcesFor(ResourceID primaryID) {
     var cachedValues = cache.get(primaryID);
     if (cachedValues == null) {
       return Collections.emptySet();
-    } else {
-      return new HashSet<>(cache.get(primaryID).values());
     }
+    return new HashSet<>(cachedValues.values());
   }
 
   public Optional<R> getSecondaryResource(ResourceID primaryID) {
@@ -269,6 +280,12 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     }
   }
 
+  /**
+   * @return a live, unmodifiable view of the cache. Note that the nested per-primary maps are not
+   *     thread safe and are mutated while holding this object's monitor, so iterating them without
+   *     synchronizing on this event source is not safe. Prefer {@link
+   *     #getSecondaryResources(ResourceID)}, which returns a snapshot.
+   */
   public Map<ResourceID, Map<ID, R>> getCache() {
     return Collections.unmodifiableMap(cache);
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/inbound/CachingInboundEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/inbound/CachingInboundEventSource.java
@@ -16,7 +16,6 @@
 package io.javaoperatorsdk.operator.processing.event.source.inbound;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -76,9 +75,9 @@ public class CachingInboundEventSource<R, P extends HasMetadata, ID>
   @Override
   public Set<R> getSecondaryResources(P primary) {
     var primaryID = ResourceID.fromResource(primary);
-    var cachedValue = cache.get(primaryID);
-    if (cachedValue != null && !cachedValue.isEmpty()) {
-      return new HashSet<>(cachedValue.values());
+    var cachedValues = cachedResourcesFor(primaryID);
+    if (!cachedValues.isEmpty()) {
+      return cachedValues;
     } else {
       if (fetchedForPrimaries.contains(primaryID)) {
         return Collections.emptySet();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
@@ -17,7 +17,6 @@ package io.javaoperatorsdk.operator.processing.event.source.polling;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -123,9 +122,8 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata, ID>
     var primaryID = ResourceID.fromResource(resource);
     if (scheduledFutures.get(primaryID) == null
         && (registerPredicate == null || registerPredicate.test(resource))) {
-      var cachedResources = cache.get(primaryID);
-      var actualResources =
-          cachedResources == null ? null : new HashSet<>(cachedResources.values());
+      var cachedResources = cachedResourcesFor(primaryID);
+      var actualResources = cachedResources.isEmpty() ? null : cachedResources;
       // note that there is a delay, to not do two fetches when the resources first appeared
       // and getSecondaryResource is called on reconciliation.
       scheduleNextExecution(resource, actualResources);
@@ -167,9 +165,9 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata, ID>
   @Override
   public Set<R> getSecondaryResources(P primary) {
     var primaryID = ResourceID.fromResource(primary);
-    var cachedValue = cache.get(primaryID);
-    if (cachedValue != null && !cachedValue.isEmpty()) {
-      return new HashSet<>(cachedValue.values());
+    var cachedValues = cachedResourcesFor(primaryID);
+    if (!cachedValues.isEmpty()) {
+      return cachedValues;
     } else {
       if (fetchedForPrimaries.contains(primaryID)) {
         return Collections.emptySet();

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSourceTest.java
@@ -223,16 +223,6 @@ class ExternalResourceCachingEventSourceTest
   }
 
   @Test
-  void recentResourceUpdateIsIgnoredForUnknownSecondaryResource() {
-    source.handleResources(primaryID1(), Set.of(testResource1()));
-
-    // testResource2 has a different id, so it is not present in the cache for primaryID1
-    var unknown = testResource2();
-    source.handleRecentResourceUpdate(primaryID1(), unknown, unknown);
-
-    assertThat(source.getSecondaryResources(primaryID1())).containsExactly(testResource1());
-  }
-
   void onlyGenericFilterSetDoesNotFailOnAdd() {
     var eventSource = new TestExternalCachingEventSource();
     eventSource.setGenericFilter(res -> true);
@@ -241,6 +231,17 @@ class ExternalResourceCachingEventSourceTest
     source.handleResources(primaryID1(), Set.of(testResource1()));
 
     verify(eventHandler, times(1)).handleEvent(any());
+  }
+
+  @Test
+  void recentResourceUpdateIsIgnoredForUnknownSecondaryResource() {
+    source.handleResources(primaryID1(), Set.of(testResource1()));
+
+    // testResource2 has a different id, so it is not present in the cache for primaryID1
+    var unknown = testResource2();
+    source.handleRecentResourceUpdate(primaryID1(), unknown, unknown);
+
+    assertThat(source.getSecondaryResources(primaryID1())).containsExactly(testResource1());
   }
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSourceTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSourceTest.java
@@ -212,6 +212,17 @@ class ExternalResourceCachingEventSourceTest
   }
 
   @Test
+  void getSecondaryResourcesReturnsASnapshotNotALiveView() {
+    source.handleResources(primaryID1(), Set.of(testResource1()));
+
+    var snapshot = source.getSecondaryResources(primaryID1());
+    source.handleDelete(primaryID1());
+
+    assertThat(snapshot).containsExactly(testResource1());
+    assertThat(source.getSecondaryResources(primaryID1())).isEmpty();
+  }
+
+  @Test
   void recentResourceUpdateIsIgnoredForUnknownSecondaryResource() {
     source.handleResources(primaryID1(), Set.of(testResource1()));
 


### PR DESCRIPTION
`ExternalResourceCachingEventSource` mutates its cache from `synchronized`
methods (`handleResources`, `handleDelete`,
`handleRecentResourceCreate/Update`), but the read paths were not
synchronized. The outer map is a `ConcurrentHashMap`; the nested
per-primary maps are plain `HashMap`s that `handleDelete` mutates in
place, so a reconciler thread reading them while a poll or informer
thread writes can observe a corrupted map or throw.

`getSecondaryResources(ResourceID)` additionally looked the primary up
twice:

    var cachedValues = cache.get(primaryID);
    if (cachedValues == null) { return Collections.emptySet(); }
    else { return new HashSet<>(cache.get(primaryID).values()); }

If a concurrent `handleDelete` removes the entry between the two calls,
the second `get` returns null and this throws a NullPointerException.

Adds a `cachedResourcesFor` helper that snapshots the cached resources
while holding the monitor, and routes `getSecondaryResources` plus the
`PerResourcePollingEventSource` and `CachingInboundEventSource` overrides
(and `checkAndRegisterTask`) through it. The helper only copies, so the
potentially slow `ResourceFetcher` calls in those overrides still run
outside the lock and cannot block the informer or poll threads.

`getCache()` still returns a live view for backwards compatibility, but
now documents that iterating the nested maps requires synchronizing on the
event source.

Adds a test asserting `getSecondaryResources` returns a snapshot rather
than a live view.

Part of #3517