### PR TITLE
fix: do not eagerly evaluate the cluster-scoped fallback in KubernetesResourceFetcher

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/cache/KubernetesResourceFetcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/cache/KubernetesResourceFetcher.java
@@ -45,7 +45,7 @@ public class KubernetesResourceFetcher<R extends HasMetadata>
     return resourceId
         .getNamespace()
         .map(ns -> client.resources(rClass).inNamespace(ns).withName(resourceId.getName()).get())
-        .orElse(client.resources(rClass).withName(resourceId.getName()).get());
+        .orElseGet(() -> client.resources(rClass).withName(resourceId.getName()).get());
   }
 
   public static Function<String, ResourceID> inverseNamespaceKeyFunction() {


### PR DESCRIPTION
`fetchResource` selected between a namespaced and a cluster-scoped lookup
with `Optional.orElse`:

    return resourceId.getNamespace()
        .map(ns -> client.resources(rClass).inNamespace(ns).withName(name).get())
        .orElse(client.resources(rClass).withName(name).get());

`orElse` evaluates its argument unconditionally, so every namespaced
lookup also performed the cluster-scoped GET. For a namespaced resource
type that second request either queries whichever namespace the client
happens to default to or fails outright, and its result is then thrown
away.

This runs on the `BoundedItemStore` cache-miss path
(`refreshMissingStateFromServer`), so it doubles the API server requests
for every bounded-cache refresh of a namespaced resource.

Switches to `orElseGet` so the fallback is only evaluated for
cluster-scoped resource ids.

Part of #3517