### PR TITLE
fix: use the cached desired state when selecting an external secondary resource

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractExternalDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/AbstractExternalDependentResource.java
@@ -126,7 +126,7 @@ public abstract class AbstractExternalDependentResource<
   @Override
   protected Optional<R> selectTargetSecondaryResource(
       Set<R> secondaryResources, P primary, Context<P> context) {
-    R desired = desired(primary, context);
+    R desired = getOrComputeDesired(context);
     List<R> targetResources;
     var desiredID = resourceIDMapper.idFor(desired);
     targetResources =


### PR DESCRIPTION
`AbstractExternalDependentResource.selectTargetSecondaryResource` called
`desired(primary, context)` directly instead of going through
`getOrComputeDesired(context)`.

`getOrComputeDesired` exists precisely so that `desired` is invoked at
most once per reconciliation; its javadoc states that the SDK should call
it exclusively and that `desired` should never be called directly, because
this "supports scenarios where idempotent computation of the desired state
is not feasible".

Calling `desired` directly here means it is computed an extra time on
every reconciliation of an external dependent resource: once to pick the
target secondary and again from `match`/`reconcile` via the cache. That is
wasted work in all cases, and produces an inconsistent desired state for
any implementation whose `desired` is not idempotent - exactly the case
the cache is there to support.

`KubernetesDependentResource` already routes through `getOrComputeDesired`
via `targetSecondaryResourceID`; this brings the external variant in line.

No unit test is added: the code path is only covered by the external
dependent integration tests under `operator-framework`, which need a
cluster.

Part of #3517