### PR TITLE
fix: do not NPE when adding a finalizer to a resource deleted mid-retry

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
@@ -291,7 +291,7 @@ public class PrimaryUpdateAndCacheUtils {
         },
         r -> {
           if (r == null) {
-            log.warn("Cannot add finalizer since resource not exists.");
+            log.warn("Cannot add finalizer since resource no longer exists.");
             return false;
           }
           return !r.hasFinalizer(finalizerName);

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
@@ -289,7 +289,13 @@ public class PrimaryUpdateAndCacheUtils {
           r.addFinalizer(finalizerName);
           return r;
         },
-        r -> !r.hasFinalizer(finalizerName));
+        r -> {
+          if (r == null) {
+            log.warn("Cannot add finalizer since resource not exists.");
+            return false;
+          }
+          return !r.hasFinalizer(finalizerName);
+        });
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
@@ -1085,7 +1085,13 @@ public class ResourceOperations<P extends HasMetadata> {
           r.addFinalizer(finalizerName);
           return r;
         },
-        r -> !r.hasFinalizer(finalizerName),
+        r -> {
+          if (r == null) {
+            log.warn("Cannot add finalizer since resource no longer exists.");
+            return false;
+          }
+          return !r.hasFinalizer(finalizerName);
+        },
         cacheOnly);
   }
 


### PR DESCRIPTION
`conflictRetryingPatchPrimary` / `conflictRetryingPatch` re-read the
resource from the API server after a 409 or 422 and then re-evaluate the
precondition:

    resource = operation.inNamespace(ns).withName(name).get();

`get()` returns null if the resource was deleted in the meantime, so the
next iteration calls the precondition with null. `removeFinalizer`
anticipates this:

    r -> {
      if (r == null) {
        log.warn("Cannot remove finalizer since resource not exists.");
        return false;
      }
      return r.hasFinalizer(finalizerName);
    }

but `addFinalizer` passes `r -> !r.hasFinalizer(finalizerName)`, which
throws a NullPointerException instead of exiting cleanly.

Gives `addFinalizer` the same null guard, in both `ResourceOperations` and
the deprecated `PrimaryUpdateAndCacheUtils`.

No test is added: reaching the retry path requires stubbing the client to
answer 409/422 and then 404 through the whole fabric8 DSL chain, which the
existing unit tests are not set up for.

Part of #3517