### PR TITLE
fix: use the null-guarded metrics field in the Controller constructor

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -138,7 +138,7 @@ public class Controller<P extends HasMetadata>
             kubernetesClient,
             configuration.getResourceClass());
     initAndRegisterEventSources(eventSourceContext);
-    configurationService.getMetrics().controllerRegistered(this);
+    metrics.controllerRegistered(this);
   }
 
   @Override


### PR DESCRIPTION
The constructor deliberately guards against a null `Metrics`:

    this.metrics = Optional.ofNullable(configurationService.getMetrics()).orElse(Metrics.NOOP);

but its last statement bypasses that guard and calls the getter again:

    configurationService.getMetrics().controllerRegistered(this);

so a `ConfigurationService` whose `getMetrics()` returns null fails with a
NullPointerException during controller construction, which is exactly what
the guard three lines up is meant to prevent. `EventProcessor` applies the
same `!= null ? metrics : Metrics.NOOP` guard, so the codebase does treat
a null `Metrics` as reachable even though the interface default returns
`Metrics.NOOP`.

Uses the already-resolved `metrics` field instead.

Part of #3517