### PR TITLE
fix: remove dangling placeholder from event source close warning

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventSourceManager.java
@@ -143,7 +143,7 @@ public class EventSourceManager<P extends HasMetadata>
       eventSource.stop();
       logEventSourceEvent(eventSource, "Stopped");
     } catch (Exception e) {
-      log.warn("Error closing {} -> {}", eventSource.name(), e);
+      log.warn("Error closing event source {}", eventSource.name(), e);
     }
     return null;
   }


### PR DESCRIPTION
`log.warn("Error closing {} -> {}", eventSource.name(), e)` supplies two
placeholders but only one non-throwable argument. SLF4J trims a trailing
`Throwable` and reports it as the exception, so the stack trace is logged
correctly, but the second placeholder is left unfilled and the message
renders with a literal brace pair:

    Error closing myEventSource -> {}

Drops the redundant placeholder and names what is being logged.

Note: the superficially similar calls in `InformerManager.stop` and
`InformerWrapper.start` are correct as they stand - they pass more
non-throwable arguments than placeholders, so nothing is left dangling.

Part of #3517