### PR TITLE
fix: set configuration service for default pool

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
@@ -498,6 +498,8 @@ public interface ConfigurationService {
       "Only the configuration API around informer pooling could still change in a"
           + " non-backwards-compatible way, the pooling itself is prod ready.")
   default InformerPool informerPool() {
-    return new DefaultInformerPool();
+    var pool = new DefaultInformerPool();
+    pool.setConfigurationService(this);
+    return pool;
   }
 }


### PR DESCRIPTION
This is expected for a pool to set. Event if the underlying implementation would set it, this is the correct way to handle it.