### PR TITLE
feat: detect dependent resource API version changes

### DIFF
--- a/docs/content/en/docs/documentation/dependent-resource-and-workflows/dependent-resources.md
+++ b/docs/content/en/docs/documentation/dependent-resource-and-workflows/dependent-resources.md
@@ -289,6 +289,41 @@ If you encounter this issue on an older Kubernetes version, consider changing yo
 that resource, or even upgrading your Kubernetes version. If you encounter it on a newer Kubernetes version, please log
 an issue with the JOSDK and with upstream Kubernetes.
 
+### Detecting dependent resource API version changes (experimental)
+
+When a dependent resource's CRD gains a new API version and the operator is upgraded to target it,
+comparing `actualResource.getApiVersion()` with the desired resource's API version is not a
+reliable way to detect resources that still need to be updated: the Kubernetes API server serves a
+resource using the requested, served API version regardless of which version it is actually stored
+as, so this comparison would always trivially match.
+
+`KubernetesDependentResource` therefore ignores `apiVersion` when matching. To still force a
+one-time update of dependent resources after such an upgrade, without triggering an update on every
+reconciliation, `KubernetesDependent` provides the opt-in, experimental
+`detectApiVersionChange` flag:
+
+```java
+@KubernetesDependent(detectApiVersionChange = true)
+public class MyDependentResource extends CRUDKubernetesDependentResource<MyResource, MyPrimary> {
+  // ...
+}
+```
+
+When enabled, JOSDK records the API version it applies in the `javaoperatorsdk.io/last-applied-api-version`
+annotation. On subsequent reconciliations, the resource is considered mismatched (and thus updated)
+if that recorded marker differs from the API version the operator currently uses - this also
+covers resources that predate this feature and therefore have no marker at all. Once the resource
+has been updated, the marker matches the current API version again, so no further update is
+requested until the API version changes again.
+
+This is disabled by default: existing behavior, including for resources created before this
+feature existed, is unaffected unless you opt in. It does not read or infer the actual storage
+version of the resource from the Kubernetes API, since that information is not reliably exposed;
+it only tracks what the operator itself last applied. It is also not a replacement for
+Kubernetes' [StorageVersionMigration](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/storage-version-migration/),
+which addresses migrating the stored representation of resources, a concern orthogonal to this
+feature.
+
 ## Telling JOSDK how to find which secondary resources are associated with a given primary resource
 
 [`KubernetesDependentResource`](https://github.com/java-operator-sdk/java-operator-sdk/blob/main/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java)

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependent.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependent.java
@@ -72,13 +72,13 @@ public @interface KubernetesDependent {
    * to target a new CRD version) and, in that case, request a one-time update of the actual
    * resource.
    *
-   * <p>When enabled, JOSDK records the API version it applies in the {@code
-   * javaoperatorsdk.io/last-applied-api-version} annotation. On subsequent reconciliations, the
-   * resource is considered mismatched (and thus updated) if that recorded marker differs from the
-   * API version the operator currently uses, including when the marker is missing entirely (for
-   * example on resources created before this feature was enabled). Once the resource has been
-   * updated, the marker matches the current API version again, so no further update is requested
-   * until the API version changes again.
+   * <p>When enabled, JOSDK records the API version it applies in the {@value
+   * KubernetesDependentResource#LAST_APPLIED_API_VERSION_ANNOTATION_KEY} annotation. On subsequent
+   * reconciliations, the resource is considered mismatched (and thus updated) if that recorded
+   * marker differs from the API version the operator currently uses, including when the marker is
+   * missing entirely (for example on resources created before this feature was enabled). Once the
+   * resource has been updated, the marker matches the current API version again, so no further
+   * update is requested until the API version changes again.
    *
    * <p>This is opt-in and disabled by default: when disabled, no marker annotation is ever added or
    * read, and matching behavior is unchanged. It does not read or infer the actual storage version

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependent.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependent.java
@@ -21,6 +21,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.javaoperatorsdk.operator.api.config.informer.Informer;
+import io.javaoperatorsdk.operator.api.reconciler.Experimental;
+
+import static io.javaoperatorsdk.operator.api.reconciler.Experimental.API_MIGHT_CHANGE;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
@@ -62,4 +65,32 @@ public @interface KubernetesDependent {
    */
   Class<? extends SSABasedGenericKubernetesResourceMatcher> matcher() default
       SSABasedGenericKubernetesResourceMatcher.class;
+
+  /**
+   * Whether JOSDK should detect that the API version of this dependent resource's desired state has
+   * changed since it was last applied by the operator (for example after the operator was upgraded
+   * to target a new CRD version) and, in that case, request a one-time update of the actual
+   * resource.
+   *
+   * <p>When enabled, JOSDK records the API version it applies in the {@code
+   * javaoperatorsdk.io/last-applied-api-version} annotation. On subsequent reconciliations, the
+   * resource is considered mismatched (and thus updated) if that recorded marker differs from the
+   * API version the operator currently uses, including when the marker is missing entirely (for
+   * example on resources created before this feature was enabled). Once the resource has been
+   * updated, the marker matches the current API version again, so no further update is requested
+   * until the API version changes again.
+   *
+   * <p>This is opt-in and disabled by default: when disabled, no marker annotation is ever added or
+   * read, and matching behavior is unchanged. It does not read or infer the actual storage version
+   * of the resource in Kubernetes, since that information is not reliably exposed by the API
+   * server; it only tracks what the operator itself last applied. It is not a replacement for
+   * Kubernetes' <a
+   * href="https://kubernetes.io/docs/tasks/manage-kubernetes-objects/storage-version-migration/">StorageVersionMigration</a>.
+   *
+   * @return {@code true} if API version change detection is enabled, {@code false} otherwise
+   * @since 5.6
+   */
+  @Experimental(API_MIGHT_CHANGE)
+  boolean detectApiVersionChange() default
+      KubernetesDependentResourceConfig.DEFAULT_DETECT_API_VERSION_CHANGE;
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentConverter.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentConverter.java
@@ -35,6 +35,8 @@ public class KubernetesDependentConverter<R extends HasMetadata, P extends HasMe
       ControllerConfiguration<?> controllerConfig) {
     var createResourceOnlyIfNotExistingWithSSA =
         DEFAULT_CREATE_RESOURCE_ONLY_IF_NOT_EXISTING_WITH_SSA;
+    var detectApiVersionChange =
+        KubernetesDependentResourceConfig.DEFAULT_DETECT_API_VERSION_CHANGE;
 
     Boolean useSSA = null;
     SSABasedGenericKubernetesResourceMatcher<R> matcher =
@@ -43,6 +45,7 @@ public class KubernetesDependentConverter<R extends HasMetadata, P extends HasMe
       createResourceOnlyIfNotExistingWithSSA =
           configAnnotation.createResourceOnlyIfNotExistingWithSSA();
       useSSA = configAnnotation.useSSA().asBoolean();
+      detectApiVersionChange = configAnnotation.detectApiVersionChange();
 
       // check if we have a specific matcher
       Class<? extends KubernetesDependentResource<?, ?>> dependentResourceClass =
@@ -62,7 +65,11 @@ public class KubernetesDependentConverter<R extends HasMetadata, P extends HasMe
             controllerConfig);
 
     return new KubernetesDependentResourceConfig<>(
-        useSSA, createResourceOnlyIfNotExistingWithSSA, informerConfiguration, matcher);
+        useSSA,
+        createResourceOnlyIfNotExistingWithSSA,
+        informerConfiguration,
+        matcher,
+        detectApiVersionChange);
   }
 
   @SuppressWarnings({"unchecked"})

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -15,6 +15,7 @@
  */
 package io.javaoperatorsdk.operator.processing.dependent.kubernetes;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -169,6 +170,12 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
 
   protected void addMetadata(
       boolean forMatch, R actualResource, final R target, P primary, Context<P> context) {
+    if (kubernetesDependentResourceConfig != null
+        && kubernetesDependentResourceConfig.detectApiVersionChange()) {
+      // desired resources might expose a null or immutable annotations map (e.g. Map.of(...));
+      // make sure it's a mutable one before this method or its callees write to it
+      ensureMutableAnnotations(target);
+    }
     if (forMatch) { // keep the current previous annotation
       String actual =
           actualResource
@@ -184,6 +191,12 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
     }
     addLastAppliedApiVersion(target);
     addReferenceHandlingMetadata(target, primary);
+  }
+
+  private static void ensureMutableAnnotations(HasMetadata target) {
+    var metadata = target.getMetadata();
+    metadata.setAnnotations(
+        new LinkedHashMap<>(Optional.ofNullable(metadata.getAnnotations()).orElseGet(Map::of)));
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -52,6 +52,15 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
 
   private static final Logger log = LoggerFactory.getLogger(KubernetesDependentResource.class);
 
+  /**
+   * Annotation used to record the API version the operator applied to this resource, when {@link
+   * KubernetesDependentResourceConfig#detectApiVersionChange()} is enabled.
+   *
+   * @see KubernetesDependent#detectApiVersionChange()
+   */
+  public static final String LAST_APPLIED_API_VERSION_ANNOTATION_KEY =
+      "javaoperatorsdk.io/last-applied-api-version";
+
   private final boolean garbageCollected = this instanceof GarbageCollected;
   private KubernetesDependentResourceConfig<R> kubernetesDependentResourceConfig;
   private volatile Boolean useSSA;
@@ -173,7 +182,28 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
         annotations.remove(InformerEventSource.PREVIOUS_ANNOTATION_KEY);
       }
     }
+    addLastAppliedApiVersion(target);
     addReferenceHandlingMetadata(target, primary);
+  }
+
+  /**
+   * When {@link KubernetesDependentResourceConfig#detectApiVersionChange()} is enabled, marks the
+   * target resource with the API version the operator is currently applying. Comparing this marker
+   * with the one recorded on the actual resource lets the regular matching logic detect a mismatch,
+   * without ever inspecting the actual, potentially unreliable, stored API version.
+   */
+  private void addLastAppliedApiVersion(R target) {
+    if (kubernetesDependentResourceConfig == null
+        || !kubernetesDependentResourceConfig.detectApiVersionChange()) {
+      return;
+    }
+    var apiVersion = target.getApiVersion();
+    if (apiVersion != null) {
+      target
+          .getMetadata()
+          .getAnnotations()
+          .put(LAST_APPLIED_API_VERSION_ANNOTATION_KEY, apiVersion);
+    }
   }
 
   protected boolean useSSA(Context<P> context) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceConfig.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceConfig.java
@@ -21,11 +21,13 @@ import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
 public class KubernetesDependentResourceConfig<R extends HasMetadata> {
 
   public static final boolean DEFAULT_CREATE_RESOURCE_ONLY_IF_NOT_EXISTING_WITH_SSA = true;
+  public static final boolean DEFAULT_DETECT_API_VERSION_CHANGE = false;
 
   private final Boolean useSSA;
   private final boolean createResourceOnlyIfNotExistingWithSSA;
   private final InformerConfiguration<R> informerConfig;
   private final SSABasedGenericKubernetesResourceMatcher<R> matcher;
+  private final boolean detectApiVersionChange;
 
   public KubernetesDependentResourceConfig(
       Boolean useSSA,
@@ -39,11 +41,26 @@ public class KubernetesDependentResourceConfig<R extends HasMetadata> {
       boolean createResourceOnlyIfNotExistingWithSSA,
       InformerConfiguration<R> informerConfig,
       SSABasedGenericKubernetesResourceMatcher<R> matcher) {
+    this(
+        useSSA,
+        createResourceOnlyIfNotExistingWithSSA,
+        informerConfig,
+        matcher,
+        DEFAULT_DETECT_API_VERSION_CHANGE);
+  }
+
+  public KubernetesDependentResourceConfig(
+      Boolean useSSA,
+      boolean createResourceOnlyIfNotExistingWithSSA,
+      InformerConfiguration<R> informerConfig,
+      SSABasedGenericKubernetesResourceMatcher<R> matcher,
+      boolean detectApiVersionChange) {
     this.useSSA = useSSA;
     this.createResourceOnlyIfNotExistingWithSSA = createResourceOnlyIfNotExistingWithSSA;
     this.informerConfig = informerConfig;
     this.matcher =
         matcher != null ? matcher : SSABasedGenericKubernetesResourceMatcher.getInstance();
+    this.detectApiVersionChange = detectApiVersionChange;
   }
 
   public boolean createResourceOnlyIfNotExistingWithSSA() {
@@ -60,5 +77,17 @@ public class KubernetesDependentResourceConfig<R extends HasMetadata> {
 
   public SSABasedGenericKubernetesResourceMatcher<R> matcher() {
     return matcher;
+  }
+
+  /**
+   * Whether JOSDK should detect when the API version of this dependent resource's desired state has
+   * changed since it was last applied by the operator and, in that case, request a one-time update
+   * of the actual resource.
+   *
+   * @return {@code true} if API version change detection is enabled, {@code false} otherwise
+   * @since 5.6
+   */
+  public boolean detectApiVersionChange() {
+    return detectApiVersionChange;
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceConfigBuilder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceConfigBuilder.java
@@ -24,6 +24,8 @@ public final class KubernetesDependentResourceConfigBuilder<R extends HasMetadat
   private Boolean useSSA = null;
   private InformerConfiguration<R> informerConfiguration;
   private SSABasedGenericKubernetesResourceMatcher<R> matcher;
+  private boolean detectApiVersionChange =
+      KubernetesDependentResourceConfig.DEFAULT_DETECT_API_VERSION_CHANGE;
 
   public KubernetesDependentResourceConfigBuilder() {}
 
@@ -51,8 +53,18 @@ public final class KubernetesDependentResourceConfigBuilder<R extends HasMetadat
     return this;
   }
 
+  public KubernetesDependentResourceConfigBuilder<R> withDetectApiVersionChange(
+      boolean detectApiVersionChange) {
+    this.detectApiVersionChange = detectApiVersionChange;
+    return this;
+  }
+
   public KubernetesDependentResourceConfig<R> build() {
     return new KubernetesDependentResourceConfig<>(
-        useSSA, createResourceOnlyIfNotExistingWithSSA, informerConfiguration, matcher);
+        useSSA,
+        createResourceOnlyIfNotExistingWithSSA,
+        informerConfiguration,
+        matcher,
+        detectApiVersionChange);
   }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentConverterTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentConverterTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.processing.dependent.kubernetes;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.GarbageCollected;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Focused unit test for the {@code detectApiVersionChange} wiring performed by {@link
+ * KubernetesDependentConverter}, independent of the shared, process-wide {@link
+ * io.javaoperatorsdk.operator.api.config.dependent.DependentResourceConfigurationResolver} state
+ * that other tests in this module mutate.
+ */
+class KubernetesDependentConverterTest {
+
+  private final KubernetesDependentConverter<GenericKubernetesResource, ConfigMap> converter =
+      new KubernetesDependentConverter<>();
+
+  @Test
+  void detectApiVersionChangeDefaultsToFalseWhenAnnotationAbsent() {
+    var config =
+        converter.configFrom(null, spec(PlainWidgetDependentResource.class), controllerConfig());
+
+    assertThat(config.detectApiVersionChange()).isFalse();
+  }
+
+  @Test
+  void detectApiVersionChangeDefaultsToFalseWhenNotSetOnAnnotation() {
+    var annotation = PlainWidgetDependentResource.class.getAnnotation(KubernetesDependent.class);
+    var config =
+        converter.configFrom(
+            annotation, spec(PlainWidgetDependentResource.class), controllerConfig());
+
+    assertThat(config.detectApiVersionChange()).isFalse();
+  }
+
+  @Test
+  void detectApiVersionChangeCanBeEnabledViaAnnotation() {
+    var annotation =
+        ApiVersionAwareWidgetDependentResource.class.getAnnotation(KubernetesDependent.class);
+    var config =
+        converter.configFrom(
+            annotation, spec(ApiVersionAwareWidgetDependentResource.class), controllerConfig());
+
+    assertThat(config.detectApiVersionChange()).isTrue();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static DependentResourceSpec<
+          GenericKubernetesResource,
+          ConfigMap,
+          KubernetesDependentResourceConfig<GenericKubernetesResource>>
+      spec(
+          Class<? extends KubernetesDependentResource<GenericKubernetesResource, ConfigMap>>
+              dependentResourceClass) {
+    return new DependentResourceSpec(
+        dependentResourceClass, "test", Set.of(), null, null, null, null, null);
+  }
+
+  private static ControllerConfiguration<ConfigMap> controllerConfig() {
+    ControllerConfiguration<ConfigMap> controllerConfig = mock();
+    when(controllerConfig.getName()).thenReturn("test-reconciler");
+    ConfigurationService configurationService = mock();
+    when(configurationService.dependentResourceFactory())
+        .thenReturn(DependentResourceFactory.DEFAULT);
+    when(controllerConfig.getConfigurationService()).thenReturn(configurationService);
+    return controllerConfig;
+  }
+
+  @KubernetesDependent
+  static class PlainWidgetDependentResource
+      extends KubernetesDependentResource<GenericKubernetesResource, ConfigMap>
+      implements GarbageCollected<ConfigMap> {
+    public PlainWidgetDependentResource() {
+      super(GenericKubernetesResource.class, null);
+    }
+  }
+
+  @KubernetesDependent(detectApiVersionChange = true)
+  static class ApiVersionAwareWidgetDependentResource
+      extends KubernetesDependentResource<GenericKubernetesResource, ConfigMap>
+      implements GarbageCollected<ConfigMap> {
+    public ApiVersionAwareWidgetDependentResource() {
+      super(GenericKubernetesResource.class, null);
+    }
+  }
+}

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceApiVersionChangeTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceApiVersionChangeTest.java
@@ -177,9 +177,33 @@ class KubernetesDependentResourceApiVersionChangeTest {
 
     var result = dr.match(actual, desired, primary(), context);
 
-    assertThat(result.matched()).isNotNull();
+    assertThat(result.matched())
+        .withFailMessage("A null desired API version must not prevent normal matching")
+        .isTrue();
     assertThat(desired.getMetadata().getAnnotations())
         .doesNotContainKey(KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY);
+  }
+
+  @Test
+  void nonSSA_preservesExistingAnnotationsWhenMarkingEvenIfImmutable() {
+    var dr = newDependentResource(true);
+    var context = context(false);
+
+    var actual = widget(NEW_API_VERSION, null, 3);
+    var desired = widget(NEW_API_VERSION, null, 3);
+    // simulate a desired resource whose annotations map is immutable, as returned by Map.of(...)
+    desired.getMetadata().setAnnotations(Map.of("user.example.com/owner", "team-a"));
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched())
+        .withFailMessage("A missing marker must still cause a mismatch")
+        .isFalse();
+    assertThat(desired.getMetadata().getAnnotations())
+        .withFailMessage("Existing annotations must be preserved alongside the new marker")
+        .containsEntry("user.example.com/owner", "team-a")
+        .containsEntry(
+            KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY, NEW_API_VERSION);
   }
 
   @Test
@@ -245,9 +269,9 @@ class KubernetesDependentResourceApiVersionChangeTest {
         .isFalse();
   }
 
-  private static ConfigMapDependentResourceForTest newDependentResource(
+  private static WidgetDependentResourceForTest newDependentResource(
       boolean detectApiVersionChange) {
-    var dr = new ConfigMapDependentResourceForTest();
+    var dr = new WidgetDependentResourceForTest();
     dr.configureWith(
         new KubernetesDependentResourceConfigBuilder<GenericKubernetesResource>()
             .withDetectApiVersionChange(detectApiVersionChange)
@@ -310,9 +334,9 @@ class KubernetesDependentResourceApiVersionChangeTest {
     return entry;
   }
 
-  private static class ConfigMapDependentResourceForTest
+  private static class WidgetDependentResourceForTest
       extends KubernetesDependentResource<GenericKubernetesResource, HasMetadata> {
-    public ConfigMapDependentResourceForTest() {
+    public WidgetDependentResourceForTest() {
       super(GenericKubernetesResource.class, null);
     }
   }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceApiVersionChangeTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResourceApiVersionChangeTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.processing.dependent.kubernetes;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.FieldsV1;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ManagedFieldsEntry;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.javaoperatorsdk.operator.MockKubernetesClient;
+import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the opt-in behavior enabled by {@link
+ * KubernetesDependentResourceConfig#detectApiVersionChange()}: a dependent resource is considered
+ * mismatched when the API version marker last applied by the operator differs from the one it would
+ * currently apply, without causing updates on every reconciliation once the marker is up-to-date.
+ */
+class KubernetesDependentResourceApiVersionChangeTest {
+
+  private static final String FIELD_MANAGER = "controller";
+  private static final String OLD_API_VERSION = "example.com/v1alpha1";
+  private static final String NEW_API_VERSION = "example.com/v1";
+
+  @Test
+  void featureDisabledByDefaultDoesNotAddMarker() {
+    var dr = newDependentResource(false);
+    var context = context(false);
+
+    var actual = widget(NEW_API_VERSION, null, 3);
+    var desired = widget(NEW_API_VERSION, null, 3);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched()).isTrue();
+    assertThat(desired.getMetadata().getAnnotations())
+        .doesNotContainKey(KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY);
+  }
+
+  @Test
+  void featureDisabledIgnoresPreExistingMarkerMismatch() {
+    var dr = newDependentResource(false);
+    var context = context(false);
+
+    var actual =
+        widget(
+            NEW_API_VERSION,
+            Map.of(
+                KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY,
+                OLD_API_VERSION),
+            3);
+    var desired = widget(NEW_API_VERSION, null, 3);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched())
+        .withFailMessage("Disabled feature must reproduce current, unaffected behavior")
+        .isTrue();
+  }
+
+  @Test
+  void nonSSA_missingMarkerCausesMismatchAndMarksDesired() {
+    var dr = newDependentResource(true);
+    var context = context(false);
+
+    var actual = widget(NEW_API_VERSION, null, 3);
+    var desired = widget(NEW_API_VERSION, null, 3);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched())
+        .withFailMessage("A resource with no marker annotation must be considered mismatched")
+        .isFalse();
+    assertThat(desired.getMetadata().getAnnotations())
+        .containsEntry(
+            KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY, NEW_API_VERSION);
+  }
+
+  @Test
+  void nonSSA_matchingMarkerMatches() {
+    var dr = newDependentResource(true);
+    var context = context(false);
+
+    var actual =
+        widget(
+            NEW_API_VERSION,
+            Map.of(
+                KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY,
+                NEW_API_VERSION),
+            3);
+    var desired = widget(NEW_API_VERSION, null, 3);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched()).isTrue();
+  }
+
+  @Test
+  void nonSSA_staleMarkerCausesMismatch() {
+    var dr = newDependentResource(true);
+    var context = context(false);
+
+    var actual =
+        widget(
+            NEW_API_VERSION,
+            Map.of(
+                KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY,
+                OLD_API_VERSION),
+            3);
+    var desired = widget(NEW_API_VERSION, null, 3);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched())
+        .withFailMessage("A stale marker must cause an update to be requested")
+        .isFalse();
+    assertThat(desired.getMetadata().getAnnotations())
+        .withFailMessage("The desired resource must be marked with the new API version")
+        .containsEntry(
+            KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY, NEW_API_VERSION);
+  }
+
+  @Test
+  void nonSSA_matchingMarkerStillDetectsUnrelatedSpecChanges() {
+    var dr = newDependentResource(true);
+    var context = context(false);
+
+    var actual =
+        widget(
+            NEW_API_VERSION,
+            Map.of(
+                KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY,
+                NEW_API_VERSION),
+            3);
+    var desired = widget(NEW_API_VERSION, null, 4);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched())
+        .withFailMessage("Normal spec matching must remain intact regardless of the marker")
+        .isFalse();
+  }
+
+  @Test
+  void nonSSA_missingApiVersionOnDesiredIsHandledSafely() {
+    var dr = newDependentResource(true);
+    var context = context(false);
+
+    var actual = widget(NEW_API_VERSION, null, 3);
+    var desired = widget(null, null, 3);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched()).isNotNull();
+    assertThat(desired.getMetadata().getAnnotations())
+        .doesNotContainKey(KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY);
+  }
+
+  @Test
+  void ssa_missingMarkerCausesMismatchAndMarksDesired() {
+    var dr = newDependentResource(true);
+    var context = context(true);
+
+    var actual = widget(NEW_API_VERSION, null, 3);
+    actual.getMetadata().setManagedFields(List.of(managedFieldsEntry(false)));
+    var desired = widget(NEW_API_VERSION, null, 3);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched())
+        .withFailMessage("A resource applied before the marker existed must be updated once")
+        .isFalse();
+    assertThat(desired.getMetadata().getAnnotations())
+        .containsEntry(
+            KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY, NEW_API_VERSION);
+  }
+
+  @Test
+  void ssa_matchingMarkerMatches() {
+    var dr = newDependentResource(true);
+    var context = context(true);
+
+    var actual =
+        widget(
+            NEW_API_VERSION,
+            Map.of(
+                KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY,
+                NEW_API_VERSION),
+            3);
+    actual.getMetadata().setManagedFields(List.of(managedFieldsEntry(true)));
+    var desired = widget(NEW_API_VERSION, null, 3);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched())
+        .withFailMessage("No further update should be requested once the marker is up-to-date")
+        .isTrue();
+  }
+
+  @Test
+  void ssa_staleMarkerCausesMismatch() {
+    var dr = newDependentResource(true);
+    var context = context(true);
+
+    var actual =
+        widget(
+            NEW_API_VERSION,
+            Map.of(
+                KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY,
+                OLD_API_VERSION),
+            3);
+    actual.getMetadata().setManagedFields(List.of(managedFieldsEntry(true)));
+    var desired = widget(NEW_API_VERSION, null, 3);
+
+    var result = dr.match(actual, desired, primary(), context);
+
+    assertThat(result.matched())
+        .withFailMessage("A stale marker recorded via SSA must still cause a mismatch")
+        .isFalse();
+  }
+
+  private static ConfigMapDependentResourceForTest newDependentResource(
+      boolean detectApiVersionChange) {
+    var dr = new ConfigMapDependentResourceForTest();
+    dr.configureWith(
+        new KubernetesDependentResourceConfigBuilder<GenericKubernetesResource>()
+            .withDetectApiVersionChange(detectApiVersionChange)
+            .build());
+    return dr;
+  }
+
+  private static HasMetadata primary() {
+    return mock();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Context<HasMetadata> context(boolean useSSA) {
+    Context<HasMetadata> context = mock();
+    var client = MockKubernetesClient.client(HasMetadata.class);
+    when(context.getClient()).thenReturn(client);
+
+    var configurationService = mock(ConfigurationService.class);
+    when(configurationService.shouldUseSSA(any(), any(), any())).thenReturn(useSSA);
+    ControllerConfiguration<HasMetadata> controllerConfiguration = mock();
+    when(controllerConfiguration.getConfigurationService()).thenReturn(configurationService);
+    when(controllerConfiguration.fieldManager()).thenReturn(FIELD_MANAGER);
+    when(context.getControllerConfiguration()).thenReturn(controllerConfiguration);
+    return context;
+  }
+
+  private static GenericKubernetesResource widget(
+      String apiVersion, Map<String, String> annotations, int specSize) {
+    var resource = new GenericKubernetesResource();
+    resource.setApiVersion(apiVersion);
+    resource.setKind("Widget");
+    var metadataBuilder = new ObjectMetaBuilder().withName("test").withNamespace("default");
+    if (annotations != null) {
+      metadataBuilder.withAnnotations(annotations);
+    }
+    resource.setMetadata(metadataBuilder.build());
+    resource.setAdditionalProperty("spec", Map.of("size", specSize));
+    return resource;
+  }
+
+  private static ManagedFieldsEntry managedFieldsEntry(boolean managesAnnotation) {
+    Map<String, Object> fields = new LinkedHashMap<>();
+    fields.put("f:spec", Map.of("f:size", Map.of()));
+    if (managesAnnotation) {
+      fields.put(
+          "f:metadata",
+          Map.of(
+              "f:annotations",
+              Map.of(
+                  "f:" + KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY,
+                  Map.of())));
+    }
+    var fieldsV1 = new FieldsV1();
+    fieldsV1.setAdditionalProperties(fields);
+
+    var entry = new ManagedFieldsEntry();
+    entry.setManager(FIELD_MANAGER);
+    entry.setOperation("Apply");
+    entry.setFieldsV1(fieldsV1);
+    return entry;
+  }
+
+  private static class ConfigMapDependentResourceForTest
+      extends KubernetesDependentResource<GenericKubernetesResource, HasMetadata> {
+    public ConfigMapDependentResourceForTest() {
+      super(GenericKubernetesResource.class, null);
+    }
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/detectapiversionchange/ConfigMapDependentResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/detectapiversionchange/ConfigMapDependentResource.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.dependent.detectapiversionchange;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
+
+@KubernetesDependent(detectApiVersionChange = true)
+public class ConfigMapDependentResource
+    extends CRUDKubernetesDependentResource<ConfigMap, DetectApiVersionChangeCustomResource> {
+
+  public static final String KEY = "key";
+
+  public static final AtomicInteger updateCount = new AtomicInteger(0);
+
+  @Override
+  protected ConfigMap desired(
+      DetectApiVersionChangeCustomResource primary,
+      Context<DetectApiVersionChangeCustomResource> context) {
+    ConfigMap configMap = new ConfigMap();
+    configMap.setMetadata(
+        new ObjectMetaBuilder()
+            .withName(primary.getMetadata().getName())
+            .withNamespace(primary.getMetadata().getNamespace())
+            .build());
+    configMap.setData(Map.of(KEY, "value"));
+    return configMap;
+  }
+
+  @Override
+  public ConfigMap update(
+      ConfigMap actual,
+      ConfigMap desired,
+      DetectApiVersionChangeCustomResource primary,
+      Context<DetectApiVersionChangeCustomResource> context) {
+    updateCount.incrementAndGet();
+    return super.update(actual, desired, primary, context);
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/detectapiversionchange/DetectApiVersionChangeCustomResource.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/detectapiversionchange/DetectApiVersionChangeCustomResource.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.dependent.detectapiversionchange;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.javaoperatorsdk")
+@Version("v1")
+public class DetectApiVersionChangeCustomResource extends CustomResource<Void, Void>
+    implements Namespaced {}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/detectapiversionchange/DetectApiVersionChangeIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/detectapiversionchange/DetectApiVersionChangeIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.dependent.detectapiversionchange;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.javaoperatorsdk.annotation.Sample;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Sample(
+    tldr = "Detects API version changes of a dependent resource",
+    description =
+        """
+        Shows how a dependent resource configured with `detectApiVersionChange` records the API \
+        version it applies in a marker annotation, and how a stale marker (for example left \
+        behind by an older CRD/operator version) triggers exactly one update to bring the marker \
+        back up to date, without causing further reconciliation loops.
+        """)
+class DetectApiVersionChangeIT {
+
+  public static final String TEST_RESOURCE_NAME = "test1";
+  public static final String STALE_API_VERSION = "stale.example.com/v1alpha1";
+
+  @RegisterExtension
+  LocallyRunOperatorExtension operator =
+      LocallyRunOperatorExtension.builder()
+          .withReconciler(new DetectApiVersionChangeReconciler())
+          .build();
+
+  @Test
+  void marksAndFixesStaleApiVersionMarker() {
+    operator.create(testResource());
+
+    // the marker annotation is set to the current API version on initial creation
+    await()
+        .untilAsserted(
+            () -> {
+              var configMap = operator.get(ConfigMap.class, TEST_RESOURCE_NAME);
+              assertThat(configMap).isNotNull();
+              assertThat(configMap.getMetadata().getAnnotations())
+                  .containsEntry(
+                      KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY, "v1");
+            });
+
+    // creation does not count as an update
+    await()
+        .pollDelay(Duration.ofMillis(300))
+        .untilAsserted(() -> assertThat(ConfigMapDependentResource.updateCount.get()).isZero());
+
+    // simulate a marker left behind by an older operator/CRD version
+    var configMap = operator.get(ConfigMap.class, TEST_RESOURCE_NAME);
+    configMap
+        .getMetadata()
+        .getAnnotations()
+        .put(
+            KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY, STALE_API_VERSION);
+    operator.update(configMap);
+
+    // the stale marker is detected and fixed with a single update
+    await()
+        .untilAsserted(
+            () -> {
+              var updated = operator.get(ConfigMap.class, TEST_RESOURCE_NAME);
+              assertThat(updated.getMetadata().getAnnotations())
+                  .containsEntry(
+                      KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY, "v1");
+              assertThat(ConfigMapDependentResource.updateCount.get()).isEqualTo(1);
+            });
+
+    // no further updates are triggered once the marker is up-to-date again
+    await()
+        .pollDelay(Duration.ofMillis(300))
+        .untilAsserted(() -> assertThat(ConfigMapDependentResource.updateCount.get()).isEqualTo(1));
+  }
+
+  DetectApiVersionChangeCustomResource testResource() {
+    var res = new DetectApiVersionChangeCustomResource();
+    res.setMetadata(new ObjectMetaBuilder().withName(TEST_RESOURCE_NAME).build());
+    return res;
+  }
+}

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/detectapiversionchange/DetectApiVersionChangeReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/detectapiversionchange/DetectApiVersionChangeReconciler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.javaoperatorsdk.operator.dependent.detectapiversionchange;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.javaoperatorsdk.operator.api.reconciler.*;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+
+@Workflow(dependents = {@Dependent(type = ConfigMapDependentResource.class)})
+@ControllerConfiguration
+public class DetectApiVersionChangeReconciler
+    implements Reconciler<DetectApiVersionChangeCustomResource> {
+
+  private final AtomicInteger numberOfExecutions = new AtomicInteger(0);
+
+  @Override
+  public UpdateControl<DetectApiVersionChangeCustomResource> reconcile(
+      DetectApiVersionChangeCustomResource resource,
+      Context<DetectApiVersionChangeCustomResource> context) {
+    numberOfExecutions.addAndGet(1);
+    return UpdateControl.noUpdate();
+  }
+
+  public int getNumberOfExecutions() {
+    return numberOfExecutions.get();
+  }
+}


### PR DESCRIPTION
## Summary

- Add an opt-in, experimental `detectApiVersionChange` option on `@KubernetesDependent` to detect when a dependent resource's API version has changed since the operator last applied it, and request a one-time update in that case.
- Record the API version the operator applies in the `javaoperatorsdk.io/last-applied-api-version` annotation, following the same pattern as the existing `javaoperatorsdk.io/previous` annotation.
- Reuse the existing matching machinery (both SSA-based and non-SSA) to compare the marker instead of adding special-case matcher logic, so behavior is consistent across both paths.
- Default behavior is unchanged: the feature is disabled by default and no marker annotation is ever added or read unless explicitly enabled.

## Motivation

When a dependent resource's CRD gains a new API version and the operator is upgraded to target it, comparing `actualResource.getApiVersion()` with the desired resource's API version is not a reliable way to detect resources that still need to be updated: the Kubernetes API server serves a resource using the requested, served API version regardless of what it is actually stored as, so this comparison would always trivially match. This is why `KubernetesDependentResource` already ignores `apiVersion` entirely in both matchers.

Instead of trying to infer the actual stored/storage version (which JOSDK cannot reliably observe, and which tools like [StorageVersionMigration](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/storage-version-migration/) exist to address), this PR lets JOSDK track what *the operator itself* last applied, using a persistent annotation marker, discussed in #2644.

When `detectApiVersionChange` is enabled:
- On every create/update/match, the target (desired) resource is marked with the API version the operator is currently using.
- The existing matcher (SSA or non-SSA) naturally detects a mismatch when the actual resource's recorded marker differs from - or is missing relative to - the desired marker, since it's just another annotation diff.
- Once updated, the actual resource's marker matches the desired one again, so no further updates are triggered until the API version changes again.
- This includes resources created before the feature was enabled: a missing marker is treated as a mismatch, causing a one-time update, after which matching succeeds normally.

This is explicitly not a replacement for Kubernetes' StorageVersionMigration and does not attempt to read or infer the actual stored representation of the resource.

## Public API

- New `@KubernetesDependent(detectApiVersionChange = true)` annotation attribute (default `false`), marked `@Experimental`.
- New `KubernetesDependentResourceConfig#detectApiVersionChange()` and a new (additive) constructor overload; existing constructors are unchanged.
- New `KubernetesDependentResourceConfigBuilder#withDetectApiVersionChange(boolean)`.
- New `KubernetesDependentResource.LAST_APPLIED_API_VERSION_ANNOTATION_KEY` constant (`javaoperatorsdk.io/last-applied-api-version`).

No breaking changes.

## Testing

- `./mvnw -pl operator-framework-core -am test -Dtest='KubernetesDependentResourceApiVersionChangeTest,KubernetesDependentConverterTest'`
- `./mvnw -pl operator-framework-core -am test -Dtest='GenericKubernetesResourceMatcherTest,SSABasedGenericKubernetesResourceMatcherTest,KubernetesDependentResourceTest,DependentResourceConfigurationResolverTest'`
- `./mvnw -pl operator-framework-core -am test` (full core module, 706 tests)
- `./mvnw spotless:apply` / `./mvnw spotless:check`
- `./mvnw clean install -pl '!migration'` (the `migration` module's OpenRewrite-based tests fail in this environment due to a pre-existing JDK 25 / OpenRewrite javac-internals incompatibility, unrelated to this change and not touched by it)

Fixes #2644
