### PR TITLE
fix: exclude samples from Maven Central publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -642,6 +642,20 @@
               <tokenAuth>true</tokenAuth>
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
+              <!-- The samples are demos and end-to-end tests, not artifacts to depend on, so they
+                   are not published. The Kotlin one could not be published anyway: it has no Java
+                   sources, so no javadoc jar is attached to it and Central rejects the whole
+                   deployment with "Javadocs must be provided but not found in entries". -->
+              <excludeArtifacts>
+                <excludeArtifact>sample-operators</excludeArtifact>
+                <excludeArtifact>sample-controller-namespace-deletion</excludeArtifact>
+                <excludeArtifact>sample-kotlin-operator</excludeArtifact>
+                <excludeArtifact>sample-leader-election</excludeArtifact>
+                <excludeArtifact>sample-mysql-schema-operator</excludeArtifact>
+                <excludeArtifact>sample-operations</excludeArtifact>
+                <excludeArtifact>sample-tomcat-operator</excludeArtifact>
+                <excludeArtifact>sample-webpage-operator</excludeArtifact>
+              </excludeArtifacts>
             </configuration>
           </plugin>
         </plugins>

--- a/sample-operators/kotlin-operator/pom.xml
+++ b/sample-operators/kotlin-operator/pom.xml
@@ -34,7 +34,6 @@
 
   <properties>
     <kotlin.version>2.4.10</kotlin.version>
-    <skipPublishing>true</skipPublishing>
   </properties>
 
   <dependencyManagement>

--- a/sample-operators/kotlin-operator/pom.xml
+++ b/sample-operators/kotlin-operator/pom.xml
@@ -34,6 +34,7 @@
 
   <properties>
     <kotlin.version>2.4.10</kotlin.version>
+    <skipPublishing>true</skipPublishing>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
The Kotlin module has no Java sources, so maven-javadoc-plugin attaches no
javadoc jar to it and Central rejects the whole deployment with
"Javadocs must be provided but not found in entries", which is what
broke the 5.5.1 release. It only exists as a Kotlin interop E2E test,
so keep it out of the published bundle.

But exlcuding all the e2e tests since those does not make sense to publish.