### PR TITLE
improve: followup PR for Informer Pools

### DIFF
--- a/caffeine-bounded-cache-support/src/test/java/io/javaoperatorsdk/operator/processing/event/source/cache/sample/AbstractTestReconciler.java
+++ b/caffeine-bounded-cache-support/src/test/java/io/javaoperatorsdk/operator/processing/event/source/cache/sample/AbstractTestReconciler.java
@@ -96,15 +96,14 @@ public abstract class AbstractTestReconciler<
             1); // setting max size for testing purposes
 
     var es =
-        new InformerEventSource<>(
+        new InformerEventSource<ConfigMap, P>(
             InformerEventSourceConfiguration.from(ConfigMap.class, primaryClass())
                 .withItemStore(boundedItemStore)
                 .withSecondaryToPrimaryMapper(
                     Mappers.fromOwnerReferences(
                         context.getPrimaryResourceClass(),
                         this instanceof BoundedCacheClusterScopeTestReconciler))
-                .build(),
-            context);
+                .build());
 
     return List.of(es);
   }

--- a/docs/content/en/docs/documentation/event-filters.md
+++ b/docs/content/en/docs/documentation/event-filters.md
@@ -84,7 +84,7 @@ public List<EventSource<?, MyCustomResource>> prepareEventSources(
           .withOnAddFilter(cm -> true)
           .build();
 
-  return List.of(new InformerEventSource<>(informerConfiguration, context));
+  return List.of(new InformerEventSource<>(informerConfiguration));
 }
 ```
 

--- a/docs/content/en/docs/documentation/eventing.md
+++ b/docs/content/en/docs/documentation/eventing.md
@@ -97,7 +97,7 @@ public class WebPageReconciler implements Reconciler<WebPage> {
                 InformerEventSourceConfiguration.from(Deployment.class, WebPage.class)
                         .withLabelSelector(SELECTOR)
                         .build();
-        return List.of(new InformerEventSource<>(configuration, context));
+        return List.of(new InformerEventSource<>(configuration));
     }
 
     // omitted code

--- a/docs/content/en/docs/documentation/operations/configuration.md
+++ b/docs/content/en/docs/documentation/operations/configuration.md
@@ -84,7 +84,7 @@ public class MyReconciler implements Reconciler<TestCustomResource> {
     InformerEventSource<ConfigMap, TestCustomResource> configMapES =
         new InformerEventSource<>(InformerEventSourceConfiguration.from(ConfigMap.class, TestCustomResource.class)
             .withNamespacesInheritedFromController(context)
-            .build(), context);
+            .build());
 
     return EventSourceUtils.nameEventSources(configMapES);
   }

--- a/docs/content/en/docs/documentation/working-with-es-caches.md
+++ b/docs/content/en/docs/documentation/working-with-es-caches.md
@@ -85,8 +85,7 @@ public class WebPageReconciler implements Reconciler<WebPage> {
        configMapEventSource = new InformerEventSource<>(
                 InformerEventSourceConfiguration.from(ConfigMap.class, WebPage.class)
                         .withLabelSelector(SELECTOR)
-                        .build(),
-                context);
+                        .build());
         
         return List.of(configMapEventSource);
     }
@@ -200,7 +199,7 @@ With this index in place, you can retrieve the target resources very efficiently
 ```java
 
   InformerEventSource<Job,Cluster> clusterInformer =
-          new InformerEventSource(
+          new InformerEventSource<>(
         InformerEventSourceConfiguration.from(Cluster.class, Job.class)
             .withSecondaryToPrimaryMapper(
                 cluster ->
@@ -214,7 +213,7 @@ With this index in place, you can retrieve the target resources very efficiently
                         .stream()
                         .map(ResourceID::fromResource)
                         .collect(Collectors.toSet()))
-            .withNamespacesInheritedFromController().build(), context);
+            .withNamespacesInheritedFromController().build());
 ```
 
 ## Read-cache-after-write consistency and event filtering

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -183,7 +183,7 @@ public class ConfigurationServiceOverrider {
    * Overrides the informer pool strategy used to create/share the informers backing the event
    * sources. When not set, the default (informer-sharing) pool is used.
    *
-   * <p>Custom strategies extend {@link InformerPool}, which already takes care of creating and
+   * <p>Custom strategies implement {@link InformerPool}, which already takes care of creating and
    * starting the informers.
    */
   @Experimental(

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -30,7 +30,6 @@ import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.Experimental;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
-import io.javaoperatorsdk.operator.processing.event.source.informer.pool.AbstractInformerPool;
 import io.javaoperatorsdk.operator.processing.event.source.informer.pool.InformerPool;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
@@ -184,13 +183,13 @@ public class ConfigurationServiceOverrider {
    * Overrides the informer pool strategy used to create/share the informers backing the event
    * sources. When not set, the default (informer-sharing) pool is used.
    *
-   * <p>Custom strategies extend {@link AbstractInformerPool}, which already takes care of creating
-   * and starting the informers.
+   * <p>Custom strategies extend {@link InformerPool}, which already takes care of creating and
+   * starting the informers.
    */
   @Experimental(
       "Only the configuration API around informer pooling could still change in a"
           + " non-backwards-compatible way, the pooling itself is prod ready.")
-  public ConfigurationServiceOverrider withInformerPool(AbstractInformerPool informerPool) {
+  public ConfigurationServiceOverrider withInformerPool(InformerPool informerPool) {
     this.informerPool = informerPool;
     return this;
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
@@ -76,7 +76,10 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
 
   <P extends HasMetadata> PrimaryToSecondaryMapper<P> getPrimaryToSecondaryMapper();
 
-  // todo deprecate
+  /**
+   * @deprecated use {@link InformerConfiguration#getResourceGroupVersionKind()}
+   */
+  @Deprecated(forRemoval = true)
   Optional<GroupVersionKind> getGroupVersionKind();
 
   default String name() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/KubernetesDependentResource.java
@@ -220,7 +220,7 @@ public abstract class KubernetesDependentResource<R extends HasMetadata, P exten
       configBuilder.updateFrom(kubernetesDependentResourceConfig.informerConfig());
     }
 
-    var es = new InformerEventSource<>(configBuilder.build(), context);
+    var es = new InformerEventSource<R, P>(configBuilder.build());
     setEventSource(es);
     return eventSource().orElseThrow();
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -53,9 +53,8 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
   private final PrimaryToSecondaryMapper<P> primaryToSecondaryMapper;
 
   /**
-   * @deprecated use {@link InformerEventSource(InformerEventSourceConfiguration)}
+   * @deprecated use {@link #InformerEventSource(InformerEventSourceConfiguration)}
    */
-  // todo migrate sample, separate PR?
   @Deprecated(forRemoval = true)
   public InformerEventSource(
       InformerEventSourceConfiguration<R> configuration, EventSourceContext<P> context) {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/changenamespace/ChangeNamespaceTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/changenamespace/ChangeNamespaceTestReconciler.java
@@ -42,8 +42,7 @@ public class ChangeNamespaceTestReconciler
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, ChangeNamespaceTestCustomResource.class)
-                .build(),
-            context);
+                .build());
 
     return List.of(configMapES);
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/clusterscopedresource/ClusterScopedCustomResourceReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/clusterscopedresource/ClusterScopedCustomResourceReconciler.java
@@ -79,14 +79,13 @@ public class ClusterScopedCustomResourceReconciler
   public List<EventSource<?, ClusterScopedCustomResource>> prepareEventSources(
       EventSourceContext<ClusterScopedCustomResource> context) {
     var ies =
-        new InformerEventSource<>(
+        new InformerEventSource<ConfigMap, ClusterScopedCustomResource>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, ClusterScopedCustomResource.class)
                 .withSecondaryToPrimaryMapper(
                     Mappers.fromOwnerReferences(context.getPrimaryResourceClass(), true))
                 .withLabelSelector(TEST_LABEL_KEY + "=" + TEST_LABEL_VALUE)
-                .build(),
-            context);
+                .build());
     return List.of(ies);
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/createupdateeventfilter/CreateUpdateEventFilterTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/createupdateeventfilter/CreateUpdateEventFilterTestReconciler.java
@@ -102,7 +102,9 @@ public class CreateUpdateEventFilterTestReconciler
             .withComparableResourceVersion(comparableResourceVersion)
             .build();
 
-    final var informerEventSource = new InformerEventSource<>(informerConfiguration, context);
+    final var informerEventSource =
+        new InformerEventSource<ConfigMap, CreateUpdateEventFilterTestCustomResource>(
+            informerConfiguration);
     this.configMapDR.setEventSource(informerEventSource);
 
     return List.of(informerEventSource);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/dynamicgenericeventsourceregistration/DynamicGenericEventSourceRegistrationReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/dynamicgenericeventsourceregistration/DynamicGenericEventSourceRegistrationReconciler.java
@@ -45,10 +45,8 @@ public class DynamicGenericEventSourceRegistrationReconciler
 
     context
         .eventSourceRetriever()
-        .dynamicallyRegisterEventSource(genericInformerFor(ConfigMap.class, context));
-    context
-        .eventSourceRetriever()
-        .dynamicallyRegisterEventSource(genericInformerFor(Secret.class, context));
+        .dynamicallyRegisterEventSource(genericInformerFor(ConfigMap.class));
+    context.eventSourceRetriever().dynamicallyRegisterEventSource(genericInformerFor(Secret.class));
 
     context.getClient().resource(secret(primary)).createOr(NonDeletingOperation::update);
     context.getClient().resource(configMap(primary)).createOr(NonDeletingOperation::update);
@@ -89,17 +87,14 @@ public class DynamicGenericEventSourceRegistrationReconciler
 
   private InformerEventSource<
           GenericKubernetesResource, DynamicGenericEventSourceRegistrationCustomResource>
-      genericInformerFor(
-          Class<? extends HasMetadata> clazz,
-          Context<DynamicGenericEventSourceRegistrationCustomResource> context) {
+      genericInformerFor(Class<? extends HasMetadata> clazz) {
 
     return new InformerEventSource<>(
         InformerEventSourceConfiguration.from(
                 GroupVersionKind.gvkFor(clazz),
                 DynamicGenericEventSourceRegistrationCustomResource.class)
             .withName(clazz.getSimpleName())
-            .build(),
-        context.eventSourceRetriever().eventSourceContextForDynamicRegistration());
+            .build());
   }
 
   public int getNumberOfExecutions() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/expectation/onallevent/ExpectationReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/expectation/onallevent/ExpectationReconciler.java
@@ -103,8 +103,7 @@ public class ExpectationReconciler implements Reconciler<ExpectationCustomResour
     return List.of(
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(Deployment.class, ExpectationCustomResource.class)
-                .build(),
-            context));
+                .build()));
   }
 
   private static void createDeployment(

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/expectation/periodicclean/PeriodicCleanerExpectationReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/expectation/periodicclean/PeriodicCleanerExpectationReconciler.java
@@ -128,8 +128,7 @@ public class PeriodicCleanerExpectationReconciler
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     Deployment.class, PeriodicCleanerExpectationCustomResource.class)
-                .build(),
-            context));
+                .build()));
   }
 
   private static void createDeployment(

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/fieldselector/FieldSelectorTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/fieldselector/FieldSelectorTestReconciler.java
@@ -72,8 +72,7 @@ public class FieldSelectorTestReconciler implements Reconciler<Secret>, TestExec
                 .withNamespacesInheritedFromController()
                 .withFieldSelector(
                     new FieldSelectorBuilder().withField("type", OTHER_SECRET_TYPE).build())
-                .build(),
-            context);
+                .build());
 
     return List.of(dependentSecretEventSource);
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/filter/FilterTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/filter/FilterTestReconciler.java
@@ -80,7 +80,7 @@ public class FilterTestReconciler implements Reconciler<FilterTestCustomResource
                     !newCM.getData().get(CM_VALUE_KEY).equals(CONFIG_MAP_FILTER_VALUE))
             .build();
     InformerEventSource<ConfigMap, FilterTestCustomResource> configMapES =
-        new InformerEventSource<>(informerConfiguration, context);
+        new InformerEventSource<>(informerConfiguration);
 
     return List.of(configMapES);
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/generickubernetesresourcehandling/GenericKubernetesResourceHandlingReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/generickubernetesresourcehandling/GenericKubernetesResourceHandlingReconciler.java
@@ -66,12 +66,12 @@ public class GenericKubernetesResourceHandlingReconciler
       EventSourceContext<GenericKubernetesResourceHandlingCustomResource> context) {
 
     var informerEventSource =
-        new InformerEventSource<>(
+        new InformerEventSource<
+            GenericKubernetesResource, GenericKubernetesResourceHandlingCustomResource>(
             InformerEventSourceConfiguration.from(
                     new GroupVersionKind("", VERSION, KIND),
                     GenericKubernetesResourceHandlingCustomResource.class)
-                .build(),
-            context);
+                .build());
 
     return List.of(informerEventSource);
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informereventsource/InformerEventSourceTestCustomReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informereventsource/InformerEventSourceTestCustomReconciler.java
@@ -61,7 +61,7 @@ public class InformerEventSourceTestCustomReconciler
                     InformerEventSourceTestCustomResource.class))
             .build();
 
-    return List.of(new InformerEventSource<>(config, context));
+    return List.of(new InformerEventSource<>(config));
   }
 
   @Override

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/basic/SharedInformerReconciler1.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/basic/SharedInformerReconciler1.java
@@ -45,7 +45,7 @@ public class SharedInformerReconciler1 implements Reconciler<SharedInformerCusto
     var config =
         InformerEventSourceConfiguration.from(ConfigMap.class, SharedInformerCustomResource1.class)
             .build();
-    return List.of(new InformerEventSource<>(config, context));
+    return List.of(new InformerEventSource<>(config));
   }
 
   @Override

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/basic/SharedInformerReconciler2.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/basic/SharedInformerReconciler2.java
@@ -44,7 +44,7 @@ public class SharedInformerReconciler2 implements Reconciler<SharedInformerCusto
     var config =
         InformerEventSourceConfiguration.from(ConfigMap.class, SharedInformerCustomResource2.class)
             .build();
-    return List.of(new InformerEventSource<>(config, context));
+    return List.of(new InformerEventSource<>(config));
   }
 
   @Override

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/deregister/DeregisterReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/deregister/DeregisterReconciler.java
@@ -45,7 +45,7 @@ public class DeregisterReconciler implements Reconciler<DeregisterPrimaryCustomR
     numberOfExecutions.incrementAndGet();
 
     if (primary.getSpec() != null && primary.getSpec().isRegisterEventSource()) {
-      context.eventSourceRetriever().dynamicallyRegisterEventSource(watchedEventSource(context));
+      context.eventSourceRetriever().dynamicallyRegisterEventSource(watchedEventSource());
     } else {
       context.eventSourceRetriever().dynamicallyDeRegisterEventSource(WATCHED_EVENT_SOURCE_NAME);
     }
@@ -54,7 +54,7 @@ public class DeregisterReconciler implements Reconciler<DeregisterPrimaryCustomR
   }
 
   private InformerEventSource<DeregisterWatchedCustomResource, DeregisterPrimaryCustomResource>
-      watchedEventSource(Context<DeregisterPrimaryCustomResource> context) {
+      watchedEventSource() {
     var config =
         InformerEventSourceConfiguration.from(
                 DeregisterWatchedCustomResource.class, DeregisterPrimaryCustomResource.class)
@@ -63,8 +63,7 @@ public class DeregisterReconciler implements Reconciler<DeregisterPrimaryCustomR
                 (DeregisterWatchedCustomResource watched) ->
                     Set.of(new ResourceID("ignored", watched.getMetadata().getNamespace())))
             .build();
-    return new InformerEventSource<>(
-        config, context.eventSourceRetriever().eventSourceContextForDynamicRegistration());
+    return new InformerEventSource<>(config);
   }
 
   public int getNumberOfExecutions() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/dynamic/DynamicSharedInformerReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/dynamic/DynamicSharedInformerReconciler.java
@@ -53,15 +53,13 @@ public class DynamicSharedInformerReconciler
       DynamicSharedInformerPrimaryCustomResource2 resource,
       Context<DynamicSharedInformerPrimaryCustomResource2> context) {
     numberOfExecutions.incrementAndGet();
-    context
-        .eventSourceRetriever()
-        .dynamicallyRegisterEventSource(thirdResourceEventSource(context));
+    context.eventSourceRetriever().dynamicallyRegisterEventSource(thirdResourceEventSource());
     return UpdateControl.noUpdate();
   }
 
   private InformerEventSource<
           DynamicSharedInformerThirdCustomResource, DynamicSharedInformerPrimaryCustomResource2>
-      thirdResourceEventSource(Context<DynamicSharedInformerPrimaryCustomResource2> context) {
+      thirdResourceEventSource() {
     var config =
         InformerEventSourceConfiguration.from(
                 DynamicSharedInformerThirdCustomResource.class,
@@ -71,8 +69,7 @@ public class DynamicSharedInformerReconciler
                 (DynamicSharedInformerThirdCustomResource third) ->
                     Set.of(new ResourceID(PRIMARY_NAME, third.getMetadata().getNamespace())))
             .build();
-    return new InformerEventSource<>(
-        config, context.eventSourceRetriever().eventSourceContextForDynamicRegistration());
+    return new InformerEventSource<>(config);
   }
 
   public int getNumberOfExecutions() {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/dynamic/StaticSharedInformerReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerpool/dynamic/StaticSharedInformerReconciler.java
@@ -56,7 +56,7 @@ public class StaticSharedInformerReconciler
                 (DynamicSharedInformerThirdCustomResource third) ->
                     Set.of(new ResourceID(PRIMARY_NAME, third.getMetadata().getNamespace())))
             .build();
-    return List.of(new InformerEventSource<>(config, context));
+    return List.of(new InformerEventSource<>(config));
   }
 
   @Override

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerremotecluster/InformerRemoteClusterReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/informerremotecluster/InformerRemoteClusterReconciler.java
@@ -70,7 +70,7 @@ public class InformerRemoteClusterReconciler
       EventSourceContext<InformerRemoteClusterCustomResource> context) {
 
     var es =
-        new InformerEventSource<>(
+        new InformerEventSource<ConfigMap, InformerRemoteClusterCustomResource>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, InformerRemoteClusterCustomResource.class)
                 // owner references do not work cross cluster, using
@@ -80,8 +80,7 @@ public class InformerRemoteClusterReconciler
                 // setting remote client for informer
                 .withKubernetesClient(remoteClient)
                 .withWatchAllNamespaces()
-                .build(),
-            context);
+                .build());
 
     return List.of(es);
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/latestdistinct/LatestDistinctTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/latestdistinct/LatestDistinctTestReconciler.java
@@ -126,9 +126,7 @@ public class LatestDistinctTestReconciler implements Reconciler<LatestDistinctTe
                             cm.getMetadata().getNamespace())))
             .build();
 
-    return List.of(
-        new InformerEventSource<>(configEs1, context),
-        new InformerEventSource<>(configEs2, context));
+    return List.of(new InformerEventSource<>(configEs1), new InformerEventSource<>(configEs2));
   }
 
   @Override

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/multiplesecondaryeventsource/MultipleSecondaryEventSourceReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/multiplesecondaryeventsource/MultipleSecondaryEventSourceReconciler.java
@@ -87,7 +87,7 @@ public class MultipleSecondaryEventSourceReconciler
                 })
             .build();
     InformerEventSource<ConfigMap, MultipleSecondaryEventSourceCustomResource>
-        configMapEventSource = new InformerEventSource<>(config, context);
+        configMapEventSource = new InformerEventSource<>(config);
     return List.of(configMapEventSource);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/ownerreferencemultiversion/OwnerRefMultiVersionReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/ownerreferencemultiversion/OwnerRefMultiVersionReconciler.java
@@ -77,13 +77,12 @@ public class OwnerRefMultiVersionReconciler implements Reconciler<OwnerRefMultiV
   public List<EventSource<?, OwnerRefMultiVersionCR1>> prepareEventSources(
       EventSourceContext<OwnerRefMultiVersionCR1> context) {
     var ies =
-        new InformerEventSource<>(
+        new InformerEventSource<ConfigMap, OwnerRefMultiVersionCR1>(
             InformerEventSourceConfiguration.from(ConfigMap.class, OwnerRefMultiVersionCR1.class)
                 .withSecondaryToPrimaryMapper(
                     Mappers.fromOwnerReferences(context.getPrimaryResourceClass()))
                 .withLabelSelector(LABEL_KEY + "=" + LABEL_VALUE)
-                .build(),
-            context);
+                .build());
     return List.of(ies);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primaryindexer/PrimaryIndexerTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primaryindexer/PrimaryIndexerTestReconciler.java
@@ -49,6 +49,6 @@ public class PrimaryIndexerTestReconciler extends AbstractPrimaryIndexerTestReco
                         .collect(Collectors.toSet()))
             .build();
 
-    return List.of(new InformerEventSource<>(informerConfiguration, context));
+    return List.of(new InformerEventSource<>(informerConfiguration));
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/JobReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/primarytosecondary/JobReconciler.java
@@ -123,7 +123,7 @@ public class JobReconciler implements Reconciler<Job> {
                               primary.getMetadata().getNamespace())));
     }
 
-    return List.of(new InformerEventSource<>(informerConfiguration.build(), context));
+    return List.of(new InformerEventSource<>(informerConfiguration.build()));
   }
 
   private String indexKey(String clusterName, String namespace) {

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/externalsecondaryupdate/ExternalSecondaryUpdateReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/externalsecondaryupdate/ExternalSecondaryUpdateReconciler.java
@@ -102,8 +102,7 @@ public class ExternalSecondaryUpdateReconciler
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, ExternalSecondaryUpdateCustomResource.class)
-                .build(),
-            context);
+                .build());
     return List.of(configMapEventSource);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/onrelistfilter/OnRelistFilterReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/onrelistfilter/OnRelistFilterReconciler.java
@@ -141,8 +141,7 @@ public class OnRelistFilterReconciler implements Reconciler<OnRelistFilterCustom
         new RelistAwareInformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, OnRelistFilterCustomResource.class)
-                .build(),
-            context);
+                .build());
     return List.of(configMapEventSource);
   }
 
@@ -180,9 +179,8 @@ public class OnRelistFilterReconciler implements Reconciler<OnRelistFilterCustom
     // Lets a test block until the event for its own write has been received and processed.
     private final ConcurrentMap<ResourceID, Long> latestReceivedVersion = new ConcurrentHashMap<>();
 
-    RelistAwareInformerEventSource(
-        InformerEventSourceConfiguration<R> configuration, EventSourceContext<P> context) {
-      super(configuration, context);
+    RelistAwareInformerEventSource(InformerEventSourceConfiguration<R> configuration) {
+      super(configuration);
     }
 
     @Override

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/ownsecondaryupdate/OwnSecondaryUpdateReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/ownsecondaryupdate/OwnSecondaryUpdateReconciler.java
@@ -68,8 +68,7 @@ public class OwnSecondaryUpdateReconciler implements Reconciler<OwnSecondaryUpda
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, OwnSecondaryUpdateCustomResource.class)
-                .build(),
-            context);
+                .build());
     return List.of(configMapEventSource);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/readownupdates/ReadOwnUpdatesReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/readcacheafterwrite/readownupdates/ReadOwnUpdatesReconciler.java
@@ -123,8 +123,7 @@ public class ReadOwnUpdatesReconciler implements Reconciler<ReadOwnUpdatesCustom
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, ReadOwnUpdatesCustomResource.class)
-                .build(),
-            context);
+                .build());
     configMapEventSource.addIndexers(
         Map.of(RESOURCE_VERSION_INDEX, cm -> List.of(cm.getMetadata().getResourceVersion())));
     return List.of(configMapEventSource);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/resourceoperations/SecondaryResourceOperationsReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/resourceoperations/SecondaryResourceOperationsReconciler.java
@@ -129,8 +129,7 @@ public class SecondaryResourceOperationsReconciler
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, SecondaryResourceOperationsCustomResource.class)
-                .build(),
-            context);
+                .build());
     return List.of(configMapEventSource);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/secondarytoprimaryreferencechange/TargetReconciler.java
@@ -55,7 +55,7 @@ public class TargetReconciler implements Reconciler<TargetCustomResource> {
             .withSecondaryToPrimaryMapper(new ConfigToTargetMapper())
             .build();
 
-    var ies = new InformerEventSource<>(configuration, context);
+    var ies = new InformerEventSource<ConfigCustomResource, TargetCustomResource>(configuration);
     return List.of(ies);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/simple/TestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/simple/TestReconciler.java
@@ -133,8 +133,7 @@ public class TestReconciler
     InformerEventSource<ConfigMap, TestCustomResource> es =
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(ConfigMap.class, TestCustomResource.class)
-                .build(),
-            context);
+                .build());
     return List.of(es);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/startsecondaryaccess/StartupSecondaryAccessReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/startsecondaryaccess/StartupSecondaryAccessReconciler.java
@@ -75,8 +75,7 @@ public class StartupSecondaryAccessReconciler
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, StartupSecondaryAccessCustomResource.class)
                 .withLabelSelector(LABEL_KEY + "=" + LABEL_VALUE)
-                .build(),
-            context);
+                .build());
     return List.of(cmInformer);
   }
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateDependentReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateDependentReconciler.java
@@ -50,11 +50,10 @@ public class ExternalStateDependentReconciler
   public List<EventSource<?, ExternalStateCustomResource>> prepareEventSources(
       EventSourceContext<ExternalStateCustomResource> context) {
     var configMapEventSource =
-        new InformerEventSource<>(
+        new InformerEventSource<ConfigMap, ExternalStateCustomResource>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, ExternalStateCustomResource.class)
-                .build(),
-            context);
+                .build());
     return List.of(configMapEventSource);
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/ExternalStateReconciler.java
@@ -141,8 +141,7 @@ public class ExternalStateReconciler
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, ExternalStateCustomResource.class)
-                .build(),
-            context);
+                .build());
     configMapEventSource.setEventSourcePriority(EventSourceStartPriority.RESOURCE_STATE_LOADER);
 
     final PerResourcePollingEventSource.ResourceFetcher<

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/externalstatebulkdependent/ExternalStateBulkDependentReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/externalstate/externalstatebulkdependent/ExternalStateBulkDependentReconciler.java
@@ -50,11 +50,10 @@ public class ExternalStateBulkDependentReconciler
   public List<EventSource<?, ExternalStateBulkDependentCustomResource>> prepareEventSources(
       EventSourceContext<ExternalStateBulkDependentCustomResource> context) {
     var configMapEventSource =
-        new InformerEventSource<>(
+        new InformerEventSource<ConfigMap, ExternalStateBulkDependentCustomResource>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, ExternalStateBulkDependentCustomResource.class)
-                .build(),
-            context);
+                .build());
     return List.of(configMapEventSource);
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/multipledependentresource/MultipleDependentResourceReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/multipledependentresource/MultipleDependentResourceReconciler.java
@@ -54,8 +54,7 @@ public class MultipleDependentResourceReconciler
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, MultipleDependentResourceCustomResource.class)
-                .build(),
-            context);
+                .build());
     firstDependentResourceConfigMap.setEventSource(eventSource);
     secondDependentResourceConfigMap.setEventSource(eventSource);
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/multipledependentresourcewithsametype/MultipleDependentResourceWithDiscriminatorReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/multipledependentresourcewithsametype/MultipleDependentResourceWithDiscriminatorReconciler.java
@@ -66,8 +66,7 @@ public class MultipleDependentResourceWithDiscriminatorReconciler
                 InformerEventSourceConfiguration.from(
                         ConfigMap.class,
                         MultipleDependentResourceCustomResourceNoDiscriminator.class)
-                    .build(),
-                context);
+                    .build());
     firstDependentResourceConfigMap.setEventSource(eventSource);
     secondDependentResourceConfigMap.setEventSource(eventSource);
 

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/multipledrsametypenodiscriminator/MultipleManagedDependentSameTypeNoDiscriminatorReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/multipledrsametypenodiscriminator/MultipleManagedDependentSameTypeNoDiscriminatorReconciler.java
@@ -71,8 +71,7 @@ public class MultipleManagedDependentSameTypeNoDiscriminatorReconciler
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, MultipleManagedDependentNoDiscriminatorCustomResource.class)
                 .withName(CONFIG_MAP_EVENT_SOURCE)
-                .build(),
-            context);
+                .build());
 
     return List.of(ies);
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/multiplemanageddependentsametype/MultipleManagedDependentResourceReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/multiplemanageddependentsametype/MultipleManagedDependentResourceReconciler.java
@@ -70,8 +70,7 @@ public class MultipleManagedDependentResourceReconciler
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, MultipleManagedDependentResourceCustomResource.class)
                 .withName(CONFIG_MAP_EVENT_SOURCE)
-                .build(),
-            context);
+                .build());
     return List.of(ies);
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/primaryindexer/DependentPrimaryIndexerTestReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/primaryindexer/DependentPrimaryIndexerTestReconciler.java
@@ -67,8 +67,7 @@ public class DependentPrimaryIndexerTestReconciler extends AbstractPrimaryIndexe
                             .stream()
                             .map(ResourceID::fromResource)
                             .collect(Collectors.toSet()))
-                .build(),
-            context);
+                .build());
 
     return List.of(es);
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/primarytosecondaydependent/PrimaryToSecondaryDependentReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/dependent/primarytosecondaydependent/PrimaryToSecondaryDependentReconciler.java
@@ -93,7 +93,7 @@ public class PrimaryToSecondaryDependentReconciler
                         primary.getMetadata().getNamespace()))));
 
     var es =
-        new InformerEventSource<>(
+        new InformerEventSource<ConfigMap, PrimaryToSecondaryDependentCustomResource>(
             InformerEventSourceConfiguration.from(
                     ConfigMap.class, PrimaryToSecondaryDependentCustomResource.class)
                 .withName(CONFIG_MAP_EVENT_SOURCE)
@@ -120,8 +120,7 @@ public class PrimaryToSecondaryDependentReconciler
                             .stream()
                             .map(ResourceID::fromResource)
                             .collect(Collectors.toSet()))
-                .build(),
-            context);
+                .build());
 
     return List.of(es);
   }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/complexdependent/ComplexWorkflowReconciler.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/workflow/complexdependent/ComplexWorkflowReconciler.java
@@ -89,15 +89,13 @@ public class ComplexWorkflowReconciler implements Reconciler<ComplexWorkflowCust
             InformerEventSourceConfiguration.from(
                     Service.class, ComplexWorkflowCustomResource.class)
                 .withName(SERVICE_EVENT_SOURCE_NAME)
-                .build(),
-            context);
+                .build());
     InformerEventSource<StatefulSet, ComplexWorkflowCustomResource> statefulSetEventSource =
         new InformerEventSource<>(
             InformerEventSourceConfiguration.from(
                     StatefulSet.class, ComplexWorkflowCustomResource.class)
                 .withName(STATEFUL_SET_EVENT_SOURCE_NAME)
-                .build(),
-            context);
+                .build());
     return List.of(serviceEventSource, statefulSetEventSource);
   }
 

--- a/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/WebappReconciler.java
+++ b/sample-operators/tomcat-operator/src/main/java/io/javaoperatorsdk/operator/sample/WebappReconciler.java
@@ -84,7 +84,7 @@ public class WebappReconciler implements Reconciler<Webapp>, Cleaner<Webapp> {
                         new ResourceID(
                             primary.getSpec().getTomcat(), primary.getMetadata().getNamespace())))
             .build();
-    return List.of(new InformerEventSource<>(configuration, context));
+    return List.of(new InformerEventSource<>(configuration));
   }
 
   /**

--- a/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconciler.java
+++ b/sample-operators/webpage/src/main/java/io/javaoperatorsdk/operator/sample/WebPageReconciler.java
@@ -53,29 +53,25 @@ public class WebPageReconciler implements Reconciler<WebPage> {
   @Override
   public List<EventSource<?, WebPage>> prepareEventSources(EventSourceContext<WebPage> context) {
     var configMapEventSource =
-        new InformerEventSource<>(
+        new InformerEventSource<ConfigMap, WebPage>(
             InformerEventSourceConfiguration.from(ConfigMap.class, WebPage.class)
                 .withLabelSelector(SELECTOR)
-                .build(),
-            context);
+                .build());
     var deploymentEventSource =
-        new InformerEventSource<>(
+        new InformerEventSource<Deployment, WebPage>(
             InformerEventSourceConfiguration.from(Deployment.class, WebPage.class)
                 .withLabelSelector(SELECTOR)
-                .build(),
-            context);
+                .build());
     var serviceEventSource =
-        new InformerEventSource<>(
+        new InformerEventSource<Service, WebPage>(
             InformerEventSourceConfiguration.from(Service.class, WebPage.class)
                 .withLabelSelector(SELECTOR)
-                .build(),
-            context);
+                .build());
     var ingressEventSource =
-        new InformerEventSource<>(
+        new InformerEventSource<Ingress, WebPage>(
             InformerEventSourceConfiguration.from(Ingress.class, WebPage.class)
                 .withLabelSelector(SELECTOR)
-                .build(),
-            context);
+                .build());
     return List.of(
         configMapEventSource, deploymentEventSource, serviceEventSource, ingressEventSource);
   }


### PR DESCRIPTION
- addresses deprecations
- Using `InformerPool` instead of `AbstractInformerPool` in `ConfigurationServiceOverrider`
- addresses late PR comments for Informer Pools: https://github.com/operator-framework/java-operator-sdk/pull/3325


Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
