### PR TITLE
[WIP] improve: various simplifications

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Informable.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Informable.java
@@ -15,7 +15,10 @@
  */
 package io.javaoperatorsdk.operator.api.config;
 
+import java.util.Optional;
+
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
 
 public interface Informable<R extends HasMetadata> {
@@ -28,5 +31,13 @@ public interface Informable<R extends HasMetadata> {
 
   default Class<R> getResourceClass() {
     return getInformerConfig().getResourceClass();
+  }
+
+  /**
+   * Optional, specific kubernetes client, typically to connect to a different cluster than the rest
+   * of the operator. Note that this is solely for multi cluster support.
+   */
+  default Optional<KubernetesClient> getKubernetesClient() {
+    return Optional.empty();
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
@@ -83,14 +83,6 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
     return getInformerConfig().getName();
   }
 
-  /**
-   * Optional, specific kubernetes client, typically to connect to a different cluster than the rest
-   * of the operator. Note that this is solely for multi cluster support.
-   */
-  default Optional<KubernetesClient> getKubernetesClient() {
-    return Optional.empty();
-  }
-
   class DefaultInformerEventSourceConfiguration<R extends HasMetadata>
       implements InformerEventSourceConfiguration<R> {
     private final PrimaryToSecondaryMapper<?> primaryToSecondaryMapper;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
@@ -25,12 +25,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.javaoperatorsdk.operator.OperatorException;
+import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getUID;
@@ -430,10 +430,7 @@ public class PrimaryUpdateAndCacheUtils {
     }
     try {
       P resource = (P) originalResource.getClass().getConstructor().newInstance();
-      ObjectMeta objectMeta = new ObjectMeta();
-      objectMeta.setName(originalResource.getMetadata().getName());
-      objectMeta.setNamespace(originalResource.getMetadata().getNamespace());
-      resource.setMetadata(objectMeta);
+      resource.initNameAndNamespaceFrom(originalResource);
       resource.addFinalizer(finalizerName);
       return client
           .resource(resource)
@@ -456,43 +453,10 @@ public class PrimaryUpdateAndCacheUtils {
   }
 
   public static int compareResourceVersions(HasMetadata h1, HasMetadata h2) {
-    return compareResourceVersions(
-        h1.getMetadata().getResourceVersion(), h2.getMetadata().getResourceVersion());
+    return ReconcilerUtilsInternal.validateAndCompareResourceVersions(h1, h2);
   }
 
   public static int compareResourceVersions(String v1, String v2) {
-    int v1Length = validateResourceVersion(v1);
-    int v2Length = validateResourceVersion(v2);
-    int comparison = v1Length - v2Length;
-    if (comparison != 0) {
-      return comparison;
-    }
-    for (int i = 0; i < v2Length; i++) {
-      int comp = v1.charAt(i) - v2.charAt(i);
-      if (comp != 0) {
-        return comp;
-      }
-    }
-    return 0;
-  }
-
-  private static int validateResourceVersion(String v1) {
-    int v1Length = v1.length();
-    if (v1Length == 0) {
-      throw new NonComparableResourceVersionException("Resource version is empty");
-    }
-    for (int i = 0; i < v1Length; i++) {
-      char char1 = v1.charAt(i);
-      if (char1 == '0') {
-        if (i == 0) {
-          throw new NonComparableResourceVersionException(
-              "Resource version cannot begin with 0: " + v1);
-        }
-      } else if (char1 < '0' || char1 > '9') {
-        throw new NonComparableResourceVersionException(
-            "Non numeric characters in resource version: " + v1);
-      }
-    }
-    return v1Length;
+    return ReconcilerUtilsInternal.validateAndCompareResourceVersions(v1, v2);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/ResourceOperations.java
@@ -556,7 +556,7 @@ public class ResourceOperations<P extends HasMetadata> {
    */
   public <R extends HasMetadata> R jsonPatch(
       R actualResource, UnaryOperator<R> unaryOperator, Options options) {
-    R desired = desiredForJsonPatch(actualResource, unaryOperator, options);
+    R desired = desiredForJsonPatch(actualResource, unaryOperator);
     return resourcePatch(
         desired,
         actualResource,
@@ -580,7 +580,7 @@ public class ResourceOperations<P extends HasMetadata> {
       UnaryOperator<R> unaryOperator,
       InformerEventSource<R, P> informerEventSource,
       Options options) {
-    R desired = desiredForJsonPatch(actualResource, unaryOperator, options);
+    R desired = desiredForJsonPatch(actualResource, unaryOperator);
     return resourcePatch(
         desired,
         actualResource,
@@ -620,7 +620,7 @@ public class ResourceOperations<P extends HasMetadata> {
    */
   public <R extends HasMetadata> R jsonPatchStatus(
       R actualResource, UnaryOperator<R> unaryOperator, Options options) {
-    R desired = desiredForJsonPatch(actualResource, unaryOperator, options);
+    R desired = desiredForJsonPatch(actualResource, unaryOperator);
     return resourcePatch(
         desired,
         actualResource,
@@ -645,7 +645,7 @@ public class ResourceOperations<P extends HasMetadata> {
       UnaryOperator<R> unaryOperator,
       InformerEventSource<R, P> informerEventSource,
       Options options) {
-    R desired = desiredForJsonPatch(actualResource, unaryOperator, options);
+    R desired = desiredForJsonPatch(actualResource, unaryOperator);
     return resourcePatch(
         desired,
         actualResource,
@@ -680,7 +680,7 @@ public class ResourceOperations<P extends HasMetadata> {
    * @return the patched resource as returned by the API server
    */
   public P jsonPatchPrimary(P actualResource, UnaryOperator<P> unaryOperator, Options options) {
-    P desired = desiredForJsonPatch(actualResource, unaryOperator, options);
+    P desired = desiredForJsonPatch(actualResource, unaryOperator);
     return resourcePatch(
         desired,
         actualResource,
@@ -717,7 +717,7 @@ public class ResourceOperations<P extends HasMetadata> {
    */
   public P jsonPatchPrimaryStatus(
       P actualResource, UnaryOperator<P> unaryOperator, Options options) {
-    P desired = desiredForJsonPatch(actualResource, unaryOperator, options);
+    P desired = desiredForJsonPatch(actualResource, unaryOperator);
     return resourcePatch(
         desired,
         actualResource,
@@ -1441,7 +1441,7 @@ public class ResourceOperations<P extends HasMetadata> {
   }
 
   private <T extends HasMetadata> T desiredForJsonPatch(
-      T actualResource, UnaryOperator<T> unaryOperator, Options options) {
+      T actualResource, UnaryOperator<T> unaryOperator) {
     var cloned =
         context
             .getControllerConfiguration()

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcher.java
@@ -38,6 +38,12 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
   public static final String METADATA_LABELS = "/metadata/labels";
   public static final String METADATA_ANNOTATIONS = "/metadata/annotations";
 
+  private static final List<String> SPEC_PREFIX = List.of(SPEC);
+  private static final List<String> STATUS_PREFIX = List.of(STATUS);
+  private static final List<String> METADATA_PREFIX = List.of(METADATA);
+  private static final List<String> LABELS_AND_ANNOTATIONS_PREFIX =
+      List.of(METADATA_LABELS, METADATA_ANNOTATIONS);
+
   private static final String PATH = "path";
   private static final String[] EMPTY_ARRAY = {};
 
@@ -182,11 +188,11 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
     boolean matched = true;
     for (int i = 0; i < wholeDiffJsonPatch.size() && matched; i++) {
       var node = wholeDiffJsonPatch.get(i);
-      if (nodeIsChildOf(node, List.of(SPEC))) {
+      if (nodeIsChildOf(node, SPEC_PREFIX)) {
         matched = match(valuesEquality, node, ignoreList);
-      } else if (nodeIsChildOf(node, List.of(METADATA))) {
+      } else if (nodeIsChildOf(node, METADATA_PREFIX)) {
         // conditionally consider labels and annotations
-        if (nodeIsChildOf(node, List.of(METADATA_LABELS, METADATA_ANNOTATIONS))) {
+        if (nodeIsChildOf(node, LABELS_AND_ANNOTATIONS_PREFIX)) {
           matched = match(labelsAndAnnotationsEquality, node, Collections.emptyList());
         }
       } else if (!nodeIsChildOf(node, IGNORED_FIELDS)) {
@@ -241,7 +247,7 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
     boolean matched = true;
     for (int i = 0; i < wholeDiffJsonPatch.size() && matched; i++) {
       var node = wholeDiffJsonPatch.get(i);
-      if (nodeIsChildOf(node, List.of(STATUS))) {
+      if (nodeIsChildOf(node, STATUS_PREFIX)) {
         matched = match(valuesEquality, node, Collections.emptyList());
       }
     }
@@ -261,7 +267,12 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
 
   static boolean nodeIsChildOf(JsonNode n, List<String> prefixes) {
     var path = getPath(n);
-    return prefixes.stream().anyMatch(path::startsWith);
+    for (int i = 0; i < prefixes.size(); i++) {
+      if (path.startsWith(prefixes.get(i))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   static String getPath(JsonNode n) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -38,6 +38,7 @@ import io.fabric8.kubernetes.api.model.apps.DaemonSet;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -199,25 +200,7 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
         && desired instanceof StatefulSet desiredStatefulSet) {
       var actualSpec = actualStatefulSet.getSpec();
       var desiredSpec = desiredStatefulSet.getSpec();
-      int claims = desiredSpec.getVolumeClaimTemplates().size();
-      if (claims == actualSpec.getVolumeClaimTemplates().size()) {
-        for (int i = 0; i < claims; i++) {
-          var claim = desiredSpec.getVolumeClaimTemplates().get(i);
-          if (claim.getSpec().getVolumeMode() == null) {
-            Optional.ofNullable(
-                    GenericKubernetesResource.get(
-                        actualMap, "spec", "volumeClaimTemplates", i, "spec"))
-                .map(Map.class::cast)
-                .ifPresent(m -> m.remove("volumeMode"));
-          }
-          if (claim.getStatus() == null) {
-            Optional.ofNullable(
-                    GenericKubernetesResource.get(actualMap, "spec", "volumeClaimTemplates", i))
-                .map(Map.class::cast)
-                .ifPresent(m -> m.remove("status"));
-          }
-        }
-      }
+      sanitizeVolumeClaimTemplates(actualMap, actualSpec, desiredSpec);
       sanitizePodTemplateSpec(actualMap, actualSpec.getTemplate(), desiredSpec.getTemplate());
     } else if (actual instanceof Deployment actualDeployment
         && desired instanceof Deployment desiredDeployment) {
@@ -237,6 +220,29 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
           actualMap,
           actualDaemonSet.getSpec().getTemplate(),
           desiredDaemonSet.getSpec().getTemplate());
+    }
+  }
+
+  private static void sanitizeVolumeClaimTemplates(
+      Map<String, Object> actualMap, StatefulSetSpec actualSpec, StatefulSetSpec desiredSpec) {
+    int claims = desiredSpec.getVolumeClaimTemplates().size();
+    if (claims != actualSpec.getVolumeClaimTemplates().size()) {
+      return;
+    }
+    for (int i = 0; i < claims; i++) {
+      var claim = desiredSpec.getVolumeClaimTemplates().get(i);
+      if (claim.getSpec().getVolumeMode() == null) {
+        Optional.ofNullable(
+                GenericKubernetesResource.get(actualMap, "spec", "volumeClaimTemplates", i, "spec"))
+            .map(Map.class::cast)
+            .ifPresent(m -> m.remove("volumeMode"));
+      }
+      if (claim.getStatus() == null) {
+        Optional.ofNullable(
+                GenericKubernetesResource.get(actualMap, "spec", "volumeClaimTemplates", i))
+            .map(Map.class::cast)
+            .ifPresent(m -> m.remove("status"));
+      }
     }
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
@@ -52,7 +52,7 @@ abstract class AbstractWorkflowExecutor<P extends HasMetadata> {
     this.context = context;
     this.primaryID = ResourceID.fromResource(primary);
     executorService = context.getWorkflowExecutorService();
-    results = new HashMap<>(workflow.getDependentResourcesByName().size());
+    results = new HashMap<>(workflow.size());
   }
 
   protected abstract Logger logger();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/EventProcessor.java
@@ -64,7 +64,7 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
   private final Cache<P> cache;
   private final EventSourceManager<P> eventSourceManager;
   private final RateLimiter<? extends RateLimitState> rateLimiter;
-  private final ResourceStateManager resourceStateManager = new ResourceStateManager();
+  private final ResourceStateManager resourceStateManager;
   private final Map<String, Object> metricsMetadata;
   private ExecutorService executor;
 
@@ -107,6 +107,8 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
     this.metrics = metrics != null ? metrics : Metrics.NOOP;
     this.eventSourceManager = eventSourceManager;
     this.rateLimiter = controllerConfiguration.getRateLimiter();
+    this.resourceStateManager =
+        new ResourceStateManager(controllerConfiguration.triggerReconcilerOnAllEvents());
 
     metricsMetadata =
         Optional.ofNullable(eventSourceManager.getController())
@@ -194,7 +196,7 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
                 state.getRetry(),
                 state.deleteEventPresent(),
                 state.isDeleteFinalStateUnknown());
-        state.unMarkEventReceived(triggerOnAllEvents());
+        state.unMarkEventReceived();
         metrics.reconciliationSubmitted(latest, state.getRetry(), metricsMetadata);
         log.debug("Executing events for custom resource. Scope: {}", executionScope);
         executor.execute(new ReconcilerExecutor(resourceID, executionScope));
@@ -249,10 +251,10 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
         // removed, but also the informers websocket is disconnected and later reconnected. So
         // meanwhile the resource could be deleted and recreated. In this case we just mark a new
         // event as below.
-        state.markEventReceived(triggerOnAllEvents());
+        state.markEventReceived();
       }
     } else if (!state.deleteEventPresent() && !state.processedMarkForDeletionPresent()) {
-      state.markEventReceived(triggerOnAllEvents());
+      state.markEventReceived();
     } else if (isTriggerOnAllEventAndDeleteEventPresent(state)) {
       state.markAdditionalEventAfterDeleteEvent();
     } else if (log.isDebugEnabled()) {
@@ -381,7 +383,7 @@ public class EventProcessor<P extends HasMetadata> implements EventHandler, Life
     boolean eventPresent =
         state.eventPresent()
             || (triggerOnAllEvents() && state.isAdditionalEventPresentAfterDeleteEvent());
-    state.markEventReceived(triggerOnAllEvents());
+    state.markEventReceived();
     retryAwareErrorLogging(
         state.getRetry(), eventPresent, errorHandledByReconciler, exception, executionScope);
     metrics.reconciliationFailed(

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceState.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceState.java
@@ -47,6 +47,7 @@ class ResourceState {
   }
 
   private final ResourceID id;
+  private final boolean triggerOnAllEvents;
 
   private boolean underProcessing;
   private RetryExecution retry;
@@ -55,8 +56,9 @@ class ResourceState {
   private HasMetadata lastKnownResource;
   private boolean isDeleteFinalStateUnknown = false;
 
-  public ResourceState(ResourceID id) {
+  public ResourceState(ResourceID id, boolean triggerOnAllEvents) {
     this.id = id;
+    this.triggerOnAllEvents = triggerOnAllEvents;
     eventing = EventingState.NO_EVENT_PRESENT;
   }
 
@@ -108,8 +110,8 @@ class ResourceState {
     return eventing == EventingState.PROCESSED_MARK_FOR_DELETION;
   }
 
-  public void markEventReceived(boolean isAllEventMode) {
-    if (!isAllEventMode && deleteEventPresent()) {
+  public void markEventReceived() {
+    if (!triggerOnAllEvents && deleteEventPresent()) {
       throw new IllegalStateException("Cannot receive event after a delete event received");
     }
     log.debug("Marking event received for: {}", getId());
@@ -151,7 +153,7 @@ class ResourceState {
     return lastKnownResource;
   }
 
-  public void unMarkEventReceived(boolean isAllEventReconcileMode) {
+  public void unMarkEventReceived() {
     switch (eventing) {
       case EVENT_PRESENT:
         eventing = EventingState.NO_EVENT_PRESENT;
@@ -159,12 +161,12 @@ class ResourceState {
       case PROCESSED_MARK_FOR_DELETION:
         throw new IllegalStateException("Cannot unmark processed marked for deletion.");
       case DELETE_EVENT_PRESENT:
-        if (!isAllEventReconcileMode) {
+        if (!triggerOnAllEvents) {
           throw new IllegalStateException("Cannot unmark delete event.");
         }
         break;
       case ADDITIONAL_EVENT_PRESENT_AFTER_DELETE_EVENT:
-        if (!isAllEventReconcileMode) {
+        if (!triggerOnAllEvents) {
           throw new IllegalStateException(
               "This state should not happen in non all-event-reconciliation mode");
         }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManager.java
@@ -28,6 +28,11 @@ class ResourceStateManager {
   // will process to avoid under- or over-sizing the state maps and avoid too many resizing that
   // take time and memory?
   private final Map<ResourceID, ResourceState> states = new ConcurrentHashMap<>(100);
+  private final boolean triggerOnAllEvents;
+
+  public ResourceStateManager(boolean triggerOnAllEvents) {
+    this.triggerOnAllEvents = triggerOnAllEvents;
+  }
 
   public Optional<ResourceState> getOrCreateOnResourceEvent(Event event) {
     var resourceId = event.getRelatedCustomResourceID();
@@ -36,7 +41,7 @@ class ResourceStateManager {
       return Optional.of(state);
     }
     if (event instanceof ResourceEvent) {
-      state = new ResourceState(resourceId);
+      state = new ResourceState(resourceId, triggerOnAllEvents);
       states.put(resourceId, state);
       return Optional.of(state);
     } else {
@@ -45,7 +50,7 @@ class ResourceStateManager {
   }
 
   public ResourceState getOrCreate(ResourceID resourceID) {
-    return states.computeIfAbsent(resourceID, ResourceState::new);
+    return states.computeIfAbsent(resourceID, id -> new ResourceState(id, triggerOnAllEvents));
   }
 
   public Optional<ResourceState> get(ResourceID resourceID) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
@@ -242,7 +242,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     if (cachedValues == null) {
       return Collections.emptySet();
     } else {
-      return new HashSet<>(cache.get(primaryID).values());
+      return new HashSet<>(cachedValues.values());
     }
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/EventFilterWindow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/EventFilterWindow.java
@@ -239,8 +239,7 @@ class EventFilterWindow {
       event.setPartOfReList(true);
     }
 
-    relatedEvents.put(
-        Long.valueOf(event.getResource().orElseThrow().getMetadata().getResourceVersion()), event);
+    relatedEvents.put(event.getResourceVersion(), event);
   }
 
   public synchronized void setReListStarted() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -178,7 +178,9 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
     super.start();
     // this makes sure that on first reconciliation all resources are
     // present on the index
-    manager().list().forEach(r -> primaryToSecondaryIndex.onAddOrUpdate(r, null));
+    if (useSecondaryToPrimaryIndex()) {
+      manager().list().forEach(r -> primaryToSecondaryIndex.onAddOrUpdate(r, null));
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
@@ -33,7 +33,6 @@ import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.Informable;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
-import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
 import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.Cache;
@@ -179,13 +178,11 @@ class InformerManager<R extends HasMetadata, C extends Informable<R>>
     // to see the very same instance. ConfigurationService#getKubernetesClient is expected to return
     // a stable instance, but its default implementation does create a new client on every call.
     if (targetClient == null) {
-      targetClient = controllerConfiguration.getConfigurationService().getKubernetesClient();
-      if (configuration instanceof InformerEventSourceConfiguration<?> iesc) {
-        var remoteClient = iesc.getKubernetesClient().orElse(null);
-        if (remoteClient != null) {
-          targetClient = remoteClient;
-        }
-      }
+      targetClient =
+          configuration
+              .getKubernetesClient()
+              .orElseGet(
+                  () -> controllerConfiguration.getConfigurationService().getKubernetesClient());
     }
     return targetClient;
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
@@ -124,6 +124,8 @@ public class Mappers {
       String typeKey,
       Class<? extends HasMetadata> primaryResourceType,
       boolean isLabel) {
+    final var expectedGvk = GroupVersionKind.gvkFor(primaryResourceType);
+    final var expectedGvkString = expectedGvk.toGVKString();
     return resource -> {
       final var metadata = resource.getMetadata();
       if (metadata == null) {
@@ -143,8 +145,8 @@ public class Mappers {
         String gvkSimple = map.get(typeKey);
 
         if (gvkSimple != null
-            && !GroupVersionKind.fromString(gvkSimple)
-                .equals(GroupVersionKind.gvkFor(primaryResourceType))) {
+            && !expectedGvkString.equals(gvkSimple)
+            && !GroupVersionKind.fromString(gvkSimple).equals(expectedGvk)) {
           return Set.of();
         }
 
@@ -183,7 +185,7 @@ public class Mappers {
       }
       return owners.stream()
           .filter(it -> kind.equals(it.getKind()))
-          .map(it -> new ResourceID(it.getName(), resource.getMetadata().getNamespace()))
+          .map(it -> ResourceID.fromOwnerReference(resource, it, false))
           .collect(Collectors.toSet());
     };
   }
@@ -191,16 +193,16 @@ public class Mappers {
   public static class SecondaryToPrimaryFromDefaultAnnotation
       implements SecondaryToPrimaryMapper<HasMetadata> {
 
-    private final Class<? extends HasMetadata> primaryResourceType;
+    private final SecondaryToPrimaryMapper<HasMetadata> delegate;
 
     public SecondaryToPrimaryFromDefaultAnnotation(
         Class<? extends HasMetadata> primaryResourceType) {
-      this.primaryResourceType = primaryResourceType;
+      this.delegate = Mappers.fromDefaultAnnotations(primaryResourceType);
     }
 
     @Override
     public Set<ResourceID> toPrimaryResourceIDs(HasMetadata resource) {
-      return Mappers.fromDefaultAnnotations(primaryResourceType).toPrimaryResourceIDs(resource);
+      return delegate.toPrimaryResourceIDs(resource);
     }
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/AbstractInformerPool.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/AbstractInformerPool.java
@@ -128,15 +128,11 @@ public abstract class AbstractInformerPool implements InformerPool {
                       return null;
                     });
               } else {
-                final var apiTypeClass = informer.getApiTypeClass();
-                final var fullResourceName = HasMetadata.getFullResourceName(apiTypeClass);
-                final var version = HasMetadata.getVersion(apiTypeClass);
                 throw new IllegalStateException(
                     "Cannot retrieve 'stopped' callback to listen to informer stopping for"
                         + " informer for "
-                        + fullResourceName
-                        + "/"
-                        + version);
+                        + ReconcilerUtilsInternal.getResourceTypeNameWithVersion(
+                            informer.getApiTypeClass()));
               }
             });
     if (!configurationService.stopOnInformerErrorDuringStartup()) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
@@ -76,8 +76,9 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata, ID>
 
   private Set<R> getAndCacheResource(P primary, boolean fromGetter) {
     var values = resourceFetcher.fetchResources(primary);
-    handleResources(ResourceID.fromResource(primary), values, !fromGetter);
-    fetchedForPrimaries.add(ResourceID.fromResource(primary));
+    var primaryID = ResourceID.fromResource(primary);
+    handleResources(primaryID, values, !fromGetter);
+    fetchedForPrimaries.add(primaryID);
     return values;
   }
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManagerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/event/ResourceStateManagerTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ResourceStateManagerTest {
 
-  private final ResourceStateManager manager = new ResourceStateManager();
+  private final ResourceStateManager manager = new ResourceStateManager(false);
   private final ResourceID sampleResourceID = new ResourceID("test-name");
   private final ResourceID sampleResourceID2 = new ResourceID("test-name2");
   private ResourceState state;
@@ -49,7 +49,7 @@ class ResourceStateManagerTest {
 
   @Test
   public void marksEvent() {
-    state.markEventReceived(false);
+    state.markEventReceived();
 
     assertThat(state.eventPresent()).isTrue();
     assertThat(state.deleteEventPresent()).isFalse();
@@ -65,7 +65,7 @@ class ResourceStateManagerTest {
 
   @Test
   public void afterDeleteEventMarkEventIsNotRelevant() {
-    state.markEventReceived(false);
+    state.markEventReceived();
 
     state.markDeleteEventReceived(TestUtils.testCustomResource(), true);
 
@@ -75,7 +75,7 @@ class ResourceStateManagerTest {
 
   @Test
   public void cleansUp() {
-    state.markEventReceived(false);
+    state.markEventReceived();
     state.markDeleteEventReceived(TestUtils.testCustomResource(), true);
 
     manager.remove(sampleResourceID);
@@ -91,15 +91,15 @@ class ResourceStateManagerTest {
         IllegalStateException.class,
         () -> {
           state.markDeleteEventReceived(TestUtils.testCustomResource(), true);
-          state.markEventReceived(false);
+          state.markEventReceived();
         });
   }
 
   @Test
   public void listsResourceIDSWithEventsPresent() {
-    state.markEventReceived(false);
-    state2.markEventReceived(false);
-    state.unMarkEventReceived(false);
+    state.markEventReceived();
+    state2.markEventReceived();
+    state.unMarkEventReceived();
 
     var res = manager.resourcesWithEventPresent();
 

--- a/operator-framework-junit/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
+++ b/operator-framework-junit/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
@@ -51,6 +51,7 @@ import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
 import io.javaoperatorsdk.operator.RegisteredController;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceOverrider;
 import io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider;
+import io.javaoperatorsdk.operator.api.config.Utils;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.processing.retry.Retry;
 
@@ -558,11 +559,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
 
     @SuppressWarnings("rawtypes")
     public Builder withReconciler(Class<? extends Reconciler> value) {
-      try {
-        reconcilers.add(new ReconcilerSpec(value.getConstructor().newInstance(), null));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
+      reconcilers.add(new ReconcilerSpec(Utils.instantiate(value, Reconciler.class, null), null));
       return this;
     }
 


### PR DESCRIPTION
Quality-only cleanup, no behavior changes.

Reuse:
- PrimaryUpdateAndCacheUtils#compareResourceVersions duplicated the whole
  algorithm of ReconcilerUtilsInternal#validateAndCompareResourceVersions
  (including validateResourceVersion) with no production caller; delegate
  instead so the resource-version semantics live in one place.
- addFinalizerWithSSA builds its bare SSA skeleton with
  HasMetadata#initNameAndNamespaceFrom, as ResourceOperations already does.
- AbstractInformerPool formats informer identifiers via
  ReconcilerUtilsInternal#getResourceTypeNameWithVersion.
- EventFilterWindow uses ExtendedResourceEvent#getResourceVersion.
- Mappers#fromOwnerType uses ResourceID#fromOwnerReference, like its sibling
  fromOwnerReferences.
- LocallyRunOperatorExtension instantiates reconcilers with Utils#instantiate.

Efficiency:
- Mappers#fromMetadata hoists the invariant GroupVersionKind out of the
  per-event lambda and compares the encoded string before parsing.
- SecondaryToPrimaryFromDefaultAnnotation holds one delegate mapper instead of
  building a new one on every event.
- AbstractWorkflowExecutor sizes its result map from Workflow#size instead of
  building a throwaway map of all dependents per reconciliation.
- GenericKubernetesResourceMatcher hoists the path-prefix lists to constants
  and drops the stream in nodeIsChildOf; both ran per JSON-diff node.
- ExternalResourceCachingEventSource and PerResourcePollingEventSource drop a
  duplicate cache lookup and a duplicate ResourceID.fromResource.
- InformerEventSource#start only walks the informer cache when the
  primary-to-secondary index is not the no-op implementation.

Altitude:
- Move getKubernetesClient to Informable so InformerManager resolves the
  target client polymorphically instead of downcasting to
  InformerEventSourceConfiguration.
- ResourceState keeps triggerOnAllEvents as a final field set once by
  ResourceStateManager, rather than receiving the same constant from every
  caller; the state machine's legal transitions are now readable on their own.
- Drop the unused Options parameter threaded into desiredForJsonPatch.
- Extract the volume-claim-template sanitization out of sanitizeState.
