### PR TITLE
test: fix flaky finalizer removal in TriggerReconcilerOnAllEventIT

### DIFF
--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/triggerallevent/eventing/TriggerReconcilerOnAllEventIT.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/baseapi/triggerallevent/eventing/TriggerReconcilerOnAllEventIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
 
@@ -218,13 +219,6 @@ public class TriggerReconcilerOnAllEventIT {
 
     addNoMoreExceptionAnnotation();
 
-    await()
-        .untilAsserted(
-            () -> {
-              var r = getResource();
-              assertThat(r.getMetadata().getFinalizers()).doesNotContain(FINALIZER);
-            });
-
     removeAdditionalFinalizerWaitForResourceDeletion();
   }
 
@@ -258,9 +252,24 @@ public class TriggerReconcilerOnAllEventIT {
   }
 
   private void removeAdditionalFinalizerWaitForResourceDeletion() {
-    var res = getResource();
-    res.removeFinalizer(ADDITIONAL_FINALIZER);
-    extension.update(res);
+    // The reconciler removes its own finalizer during the reconciliation triggered above, but the
+    // event count is already increased at the beginning of the reconciliation. Therefore, waiting
+    // for the event count alone would release the test into the middle of that reconciliation, and
+    // the update below would race with the finalizer removal.
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(getResource().getMetadata().getFinalizers())
+                    .containsExactly(ADDITIONAL_FINALIZER));
+    // update is optimistically locked, so retry with a fresh read on conflict
+    await()
+        .ignoreException(KubernetesClientException.class)
+        .untilAsserted(
+            () -> {
+              var res = getResource();
+              res.removeFinalizer(ADDITIONAL_FINALIZER);
+              extension.update(res);
+            });
     await().untilAsserted(() -> assertThat(getResource()).isNull());
   }
 


### PR DESCRIPTION
The event count is increased at the beginning of the reconciliation, thus
waiting for it released the test into the middle of a reconciliation that
was still about to remove the finalizer. The subsequent update then raced
with that removal and failed with a conflict.

Wait for the finalizer removal to actually land, and retry the (optimistically
locked) update with a fresh read on conflict.
