### PR TITLE
refactor: call existing helpers instead of re-implementing them

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/PrimaryUpdateAndCacheUtils.java
@@ -25,12 +25,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.javaoperatorsdk.operator.OperatorException;
+import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getUID;
@@ -430,10 +430,7 @@ public class PrimaryUpdateAndCacheUtils {
     }
     try {
       P resource = (P) originalResource.getClass().getConstructor().newInstance();
-      ObjectMeta objectMeta = new ObjectMeta();
-      objectMeta.setName(originalResource.getMetadata().getName());
-      objectMeta.setNamespace(originalResource.getMetadata().getNamespace());
-      resource.setMetadata(objectMeta);
+      resource.initNameAndNamespaceFrom(originalResource);
       resource.addFinalizer(finalizerName);
       return client
           .resource(resource)
@@ -456,43 +453,10 @@ public class PrimaryUpdateAndCacheUtils {
   }
 
   public static int compareResourceVersions(HasMetadata h1, HasMetadata h2) {
-    return compareResourceVersions(
-        h1.getMetadata().getResourceVersion(), h2.getMetadata().getResourceVersion());
+    return ReconcilerUtilsInternal.validateAndCompareResourceVersions(h1, h2);
   }
 
   public static int compareResourceVersions(String v1, String v2) {
-    int v1Length = validateResourceVersion(v1);
-    int v2Length = validateResourceVersion(v2);
-    int comparison = v1Length - v2Length;
-    if (comparison != 0) {
-      return comparison;
-    }
-    for (int i = 0; i < v2Length; i++) {
-      int comp = v1.charAt(i) - v2.charAt(i);
-      if (comp != 0) {
-        return comp;
-      }
-    }
-    return 0;
-  }
-
-  private static int validateResourceVersion(String v1) {
-    int v1Length = v1.length();
-    if (v1Length == 0) {
-      throw new NonComparableResourceVersionException("Resource version is empty");
-    }
-    for (int i = 0; i < v1Length; i++) {
-      char char1 = v1.charAt(i);
-      if (char1 == '0') {
-        if (i == 0) {
-          throw new NonComparableResourceVersionException(
-              "Resource version cannot begin with 0: " + v1);
-        }
-      } else if (char1 < '0' || char1 > '9') {
-        throw new NonComparableResourceVersionException(
-            "Non numeric characters in resource version: " + v1);
-      }
-    }
-    return v1Length;
+    return ReconcilerUtilsInternal.validateAndCompareResourceVersions(v1, v2);
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/EventFilterWindow.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/EventFilterWindow.java
@@ -239,8 +239,7 @@ class EventFilterWindow {
       event.setPartOfReList(true);
     }
 
-    relatedEvents.put(
-        Long.valueOf(event.getResource().orElseThrow().getMetadata().getResourceVersion()), event);
+    relatedEvents.put(event.getResourceVersion(), event);
   }
 
   public synchronized void setReListStarted() {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/AbstractInformerPool.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/AbstractInformerPool.java
@@ -128,15 +128,11 @@ public abstract class AbstractInformerPool implements InformerPool {
                       return null;
                     });
               } else {
-                final var apiTypeClass = informer.getApiTypeClass();
-                final var fullResourceName = HasMetadata.getFullResourceName(apiTypeClass);
-                final var version = HasMetadata.getVersion(apiTypeClass);
                 throw new IllegalStateException(
                     "Cannot retrieve 'stopped' callback to listen to informer stopping for"
                         + " informer for "
-                        + fullResourceName
-                        + "/"
-                        + version);
+                        + ReconcilerUtilsInternal.getResourceTypeNameWithVersion(
+                            informer.getApiTypeClass()));
               }
             });
     if (!configurationService.stopOnInformerErrorDuringStartup()) {

--- a/operator-framework-junit/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
+++ b/operator-framework-junit/src/main/java/io/javaoperatorsdk/operator/junit/LocallyRunOperatorExtension.java
@@ -51,6 +51,7 @@ import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
 import io.javaoperatorsdk.operator.RegisteredController;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceOverrider;
 import io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider;
+import io.javaoperatorsdk.operator.api.config.Utils;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.processing.retry.Retry;
 
@@ -558,11 +559,7 @@ public class LocallyRunOperatorExtension extends AbstractOperatorExtension {
 
     @SuppressWarnings("rawtypes")
     public Builder withReconciler(Class<? extends Reconciler> value) {
-      try {
-        reconcilers.add(new ReconcilerSpec(value.getConstructor().newInstance(), null));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
+      reconcilers.add(new ReconcilerSpec(Utils.instantiate(value, Reconciler.class, null), null));
       return this;
     }
 


### PR DESCRIPTION
No behavior change; each site is replaced by a helper that already exists.

- PrimaryUpdateAndCacheUtils#compareResourceVersions (and its private
  validateResourceVersion) duplicated the entire algorithm of
  ReconcilerUtilsInternal#validateAndCompareResourceVersions: the length-first
  compare, the empty check, the leading-zero check and the same exception
  messages. It had no production caller, so the copy could silently drift from
  the version all production paths use. Delegate instead.
- addFinalizerWithSSA builds its bare SSA skeleton with
  HasMetadata#initNameAndNamespaceFrom, which ResourceOperations already uses
  for the same purpose and which is Namespaced-aware.
- AbstractInformerPool formats the informer identifier with
  ReconcilerUtilsInternal#getResourceTypeNameWithVersion instead of
  concatenating the resource name and version by hand.
- EventFilterWindow uses ExtendedResourceEvent#getResourceVersion, which had
  no callers even though it is exactly the expression used here.
- LocallyRunOperatorExtension instantiates reconcilers with Utils#instantiate,
  so it also supports non-public no-arg constructors and reports the failing
  class instead of wrapping in a bare RuntimeException.


---

Quality-only change: no intended behavior difference. Cut from `next` and
touches a disjoint set of files from the sibling cleanup PRs, so it can be merged
independently and in any order.

Verified on this branch alone: `mvn -o -pl operator-framework-core,operator-framework-junit -am test`
(693 core + 6 junit tests, no failures) and `mvn spotless:check`.
