### PR TITLE
perf: avoid redundant work on informer event paths

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/ExternalResourceCachingEventSource.java
@@ -242,7 +242,7 @@ public abstract class ExternalResourceCachingEventSource<R, P extends HasMetadat
     if (cachedValues == null) {
       return Collections.emptySet();
     } else {
-      return new HashSet<>(cache.get(primaryID).values());
+      return new HashSet<>(cachedValues.values());
     }
   }
 

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -178,7 +178,9 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
     super.start();
     // this makes sure that on first reconciliation all resources are
     // present on the index
-    manager().list().forEach(r -> primaryToSecondaryIndex.onAddOrUpdate(r, null));
+    if (useSecondaryToPrimaryIndex()) {
+      manager().list().forEach(r -> primaryToSecondaryIndex.onAddOrUpdate(r, null));
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/Mappers.java
@@ -124,6 +124,8 @@ public class Mappers {
       String typeKey,
       Class<? extends HasMetadata> primaryResourceType,
       boolean isLabel) {
+    final var expectedGvk = GroupVersionKind.gvkFor(primaryResourceType);
+    final var expectedGvkString = expectedGvk.toGVKString();
     return resource -> {
       final var metadata = resource.getMetadata();
       if (metadata == null) {
@@ -143,8 +145,8 @@ public class Mappers {
         String gvkSimple = map.get(typeKey);
 
         if (gvkSimple != null
-            && !GroupVersionKind.fromString(gvkSimple)
-                .equals(GroupVersionKind.gvkFor(primaryResourceType))) {
+            && !expectedGvkString.equals(gvkSimple)
+            && !GroupVersionKind.fromString(gvkSimple).equals(expectedGvk)) {
           return Set.of();
         }
 
@@ -183,7 +185,7 @@ public class Mappers {
       }
       return owners.stream()
           .filter(it -> kind.equals(it.getKind()))
-          .map(it -> new ResourceID(it.getName(), resource.getMetadata().getNamespace()))
+          .map(it -> ResourceID.fromOwnerReference(resource, it, false))
           .collect(Collectors.toSet());
     };
   }
@@ -191,16 +193,16 @@ public class Mappers {
   public static class SecondaryToPrimaryFromDefaultAnnotation
       implements SecondaryToPrimaryMapper<HasMetadata> {
 
-    private final Class<? extends HasMetadata> primaryResourceType;
+    private final SecondaryToPrimaryMapper<HasMetadata> delegate;
 
     public SecondaryToPrimaryFromDefaultAnnotation(
         Class<? extends HasMetadata> primaryResourceType) {
-      this.primaryResourceType = primaryResourceType;
+      this.delegate = Mappers.fromDefaultAnnotations(primaryResourceType);
     }
 
     @Override
     public Set<ResourceID> toPrimaryResourceIDs(HasMetadata resource) {
-      return Mappers.fromDefaultAnnotations(primaryResourceType).toPrimaryResourceIDs(resource);
+      return delegate.toPrimaryResourceIDs(resource);
     }
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/polling/PerResourcePollingEventSource.java
@@ -76,8 +76,9 @@ public class PerResourcePollingEventSource<R, P extends HasMetadata, ID>
 
   private Set<R> getAndCacheResource(P primary, boolean fromGetter) {
     var values = resourceFetcher.fetchResources(primary);
-    handleResources(ResourceID.fromResource(primary), values, !fromGetter);
-    fetchedForPrimaries.add(ResourceID.fromResource(primary));
+    var primaryID = ResourceID.fromResource(primary);
+    handleResources(primaryID, values, !fromGetter);
+    fetchedForPrimaries.add(primaryID);
     return values;
   }
 


### PR DESCRIPTION
- Mappers#fromMetadata resolved the primary GroupVersionKind on every
  secondary event, although it only depends on the primary type. Hoist it out
  of the lambda and compare the encoded string before falling back to parsing
  the annotation value.
- Mappers.SecondaryToPrimaryFromDefaultAnnotation built a whole new mapper on
  every invocation; hold a single delegate instead. The primaryResourceType
  field becomes unused and is dropped.
- InformerEventSource#start walked the entire informer cache to seed the
  primary-to-secondary index even when that index is the no-op implementation
  (i.e. whenever a primaryToSecondaryMapper is configured), which is pure
  startup latency proportional to the number of cached secondaries.
- ExternalResourceCachingEventSource#getSecondaryResources looked the primary
  up in the cache a second time although the value was already in a local.
- PerResourcePollingEventSource#getAndCacheResource derived the same
  ResourceID twice in adjacent statements.


---

Quality-only change: no intended behavior difference. Cut from `next` and
touches a disjoint set of files from the sibling cleanup PRs, so it can be merged
independently and in any order.

Verified on this branch alone: `mvn -o -pl operator-framework-core,operator-framework-junit -am test`
(693 core + 6 junit tests, no failures) and `mvn spotless:check`.
