### PR TITLE
refactor: clean up the Kubernetes resource matchers

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/GenericKubernetesResourceMatcher.java
@@ -38,6 +38,12 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
   public static final String METADATA_LABELS = "/metadata/labels";
   public static final String METADATA_ANNOTATIONS = "/metadata/annotations";
 
+  private static final List<String> SPEC_PREFIX = List.of(SPEC);
+  private static final List<String> STATUS_PREFIX = List.of(STATUS);
+  private static final List<String> METADATA_PREFIX = List.of(METADATA);
+  private static final List<String> LABELS_AND_ANNOTATIONS_PREFIX =
+      List.of(METADATA_LABELS, METADATA_ANNOTATIONS);
+
   private static final String PATH = "path";
   private static final String[] EMPTY_ARRAY = {};
 
@@ -182,11 +188,11 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
     boolean matched = true;
     for (int i = 0; i < wholeDiffJsonPatch.size() && matched; i++) {
       var node = wholeDiffJsonPatch.get(i);
-      if (nodeIsChildOf(node, List.of(SPEC))) {
+      if (nodeIsChildOf(node, SPEC_PREFIX)) {
         matched = match(valuesEquality, node, ignoreList);
-      } else if (nodeIsChildOf(node, List.of(METADATA))) {
+      } else if (nodeIsChildOf(node, METADATA_PREFIX)) {
         // conditionally consider labels and annotations
-        if (nodeIsChildOf(node, List.of(METADATA_LABELS, METADATA_ANNOTATIONS))) {
+        if (nodeIsChildOf(node, LABELS_AND_ANNOTATIONS_PREFIX)) {
           matched = match(labelsAndAnnotationsEquality, node, Collections.emptyList());
         }
       } else if (!nodeIsChildOf(node, IGNORED_FIELDS)) {
@@ -241,7 +247,7 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
     boolean matched = true;
     for (int i = 0; i < wholeDiffJsonPatch.size() && matched; i++) {
       var node = wholeDiffJsonPatch.get(i);
-      if (nodeIsChildOf(node, List.of(STATUS))) {
+      if (nodeIsChildOf(node, STATUS_PREFIX)) {
         matched = match(valuesEquality, node, Collections.emptyList());
       }
     }
@@ -261,7 +267,12 @@ public class GenericKubernetesResourceMatcher<R extends HasMetadata, P extends H
 
   static boolean nodeIsChildOf(JsonNode n, List<String> prefixes) {
     var path = getPath(n);
-    return prefixes.stream().anyMatch(path::startsWith);
+    for (int i = 0; i < prefixes.size(); i++) {
+      if (path.startsWith(prefixes.get(i))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   static String getPath(JsonNode n) {

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/kubernetes/SSABasedGenericKubernetesResourceMatcher.java
@@ -38,6 +38,7 @@ import io.fabric8.kubernetes.api.model.apps.DaemonSet;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -199,25 +200,7 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
         && desired instanceof StatefulSet desiredStatefulSet) {
       var actualSpec = actualStatefulSet.getSpec();
       var desiredSpec = desiredStatefulSet.getSpec();
-      int claims = desiredSpec.getVolumeClaimTemplates().size();
-      if (claims == actualSpec.getVolumeClaimTemplates().size()) {
-        for (int i = 0; i < claims; i++) {
-          var claim = desiredSpec.getVolumeClaimTemplates().get(i);
-          if (claim.getSpec().getVolumeMode() == null) {
-            Optional.ofNullable(
-                    GenericKubernetesResource.get(
-                        actualMap, "spec", "volumeClaimTemplates", i, "spec"))
-                .map(Map.class::cast)
-                .ifPresent(m -> m.remove("volumeMode"));
-          }
-          if (claim.getStatus() == null) {
-            Optional.ofNullable(
-                    GenericKubernetesResource.get(actualMap, "spec", "volumeClaimTemplates", i))
-                .map(Map.class::cast)
-                .ifPresent(m -> m.remove("status"));
-          }
-        }
-      }
+      sanitizeVolumeClaimTemplates(actualMap, actualSpec, desiredSpec);
       sanitizePodTemplateSpec(actualMap, actualSpec.getTemplate(), desiredSpec.getTemplate());
     } else if (actual instanceof Deployment actualDeployment
         && desired instanceof Deployment desiredDeployment) {
@@ -237,6 +220,29 @@ public class SSABasedGenericKubernetesResourceMatcher<R extends HasMetadata> {
           actualMap,
           actualDaemonSet.getSpec().getTemplate(),
           desiredDaemonSet.getSpec().getTemplate());
+    }
+  }
+
+  private static void sanitizeVolumeClaimTemplates(
+      Map<String, Object> actualMap, StatefulSetSpec actualSpec, StatefulSetSpec desiredSpec) {
+    int claims = desiredSpec.getVolumeClaimTemplates().size();
+    if (claims != actualSpec.getVolumeClaimTemplates().size()) {
+      return;
+    }
+    for (int i = 0; i < claims; i++) {
+      var claim = desiredSpec.getVolumeClaimTemplates().get(i);
+      if (claim.getSpec().getVolumeMode() == null) {
+        Optional.ofNullable(
+                GenericKubernetesResource.get(actualMap, "spec", "volumeClaimTemplates", i, "spec"))
+            .map(Map.class::cast)
+            .ifPresent(m -> m.remove("volumeMode"));
+      }
+      if (claim.getStatus() == null) {
+        Optional.ofNullable(
+                GenericKubernetesResource.get(actualMap, "spec", "volumeClaimTemplates", i))
+            .map(Map.class::cast)
+            .ifPresent(m -> m.remove("status"));
+      }
     }
   }
 


### PR DESCRIPTION
- GenericKubernetesResourceMatcher allocated the path-prefix lists
  (List.of(SPEC), List.of(METADATA), the labels/annotations pair, List.of(STATUS))
  once per JSON-diff node while matching, and nodeIsChildOf built a stream per
  call. Both run for every node of every match, so hoist the lists to constants
  and use an indexed loop.
- SSABasedGenericKubernetesResourceMatcher#sanitizeState nested the StatefulSet
  volume-claim-template handling four levels deep inside the type ladder;
  extract it into sanitizeVolumeClaimTemplates so the ladder reads as one
  dispatch per resource kind.


---

Quality-only change: no intended behavior difference. Cut from `next` and
touches a disjoint set of files from the sibling cleanup PRs, so it can be merged
independently and in any order.

Verified on this branch alone: `mvn -o -pl operator-framework-core,operator-framework-junit -am test`
(693 core + 6 junit tests, no failures) and `mvn spotless:check`.
