### PR TITLE
perf: size the workflow result map from Workflow#size

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/dependent/workflow/AbstractWorkflowExecutor.java
@@ -52,7 +52,7 @@ abstract class AbstractWorkflowExecutor<P extends HasMetadata> {
     this.context = context;
     this.primaryID = ResourceID.fromResource(primary);
     executorService = context.getWorkflowExecutorService();
-    results = new HashMap<>(workflow.getDependentResourcesByName().size());
+    results = new HashMap<>(workflow.size());
   }
 
   protected abstract Logger logger();


### PR DESCRIPTION
AbstractWorkflowExecutor called Workflow#getDependentResourcesByName purely to
read its size. That allocates a HashMap and walks every node to collect the
dependent resources, then discards the map. The executor is constructed on
every reconcile and cleanup of a workflow-based reconciler, so use the existing
Workflow#size instead.


---

Quality-only change: no intended behavior difference. Cut from `next` and
touches a disjoint set of files from the sibling cleanup PRs, so it can be merged
independently and in any order.

Verified on this branch alone: `mvn -o -pl operator-framework-core,operator-framework-junit -am test`
(693 core + 6 junit tests, no failures) and `mvn spotless:check`.
