### PR TITLE
refactor: resolve the informer target client without a downcast

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Informable.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/Informable.java
@@ -15,7 +15,10 @@
  */
 package io.javaoperatorsdk.operator.api.config;
 
+import java.util.Optional;
+
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
 
 public interface Informable<R extends HasMetadata> {
@@ -28,5 +31,13 @@ public interface Informable<R extends HasMetadata> {
 
   default Class<R> getResourceClass() {
     return getInformerConfig().getResourceClass();
+  }
+
+  /**
+   * Optional, specific kubernetes client, typically to connect to a different cluster than the rest
+   * of the operator. Note that this is solely for multi cluster support.
+   */
+  default Optional<KubernetesClient> getKubernetesClient() {
+    return Optional.empty();
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/informer/InformerEventSourceConfiguration.java
@@ -83,14 +83,6 @@ public interface InformerEventSourceConfiguration<R extends HasMetadata> extends
     return getInformerConfig().getName();
   }
 
-  /**
-   * Optional, specific kubernetes client, typically to connect to a different cluster than the rest
-   * of the operator. Note that this is solely for multi cluster support.
-   */
-  default Optional<KubernetesClient> getKubernetesClient() {
-    return Optional.empty();
-  }
-
   class DefaultInformerEventSourceConfiguration<R extends HasMetadata>
       implements InformerEventSourceConfiguration<R> {
     private final PrimaryToSecondaryMapper<?> primaryToSecondaryMapper;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerManager.java
@@ -33,7 +33,6 @@ import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.Informable;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
-import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
 import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.Cache;
@@ -179,13 +178,11 @@ class InformerManager<R extends HasMetadata, C extends Informable<R>>
     // to see the very same instance. ConfigurationService#getKubernetesClient is expected to return
     // a stable instance, but its default implementation does create a new client on every call.
     if (targetClient == null) {
-      targetClient = controllerConfiguration.getConfigurationService().getKubernetesClient();
-      if (configuration instanceof InformerEventSourceConfiguration<?> iesc) {
-        var remoteClient = iesc.getKubernetesClient().orElse(null);
-        if (remoteClient != null) {
-          targetClient = remoteClient;
-        }
-      }
+      targetClient =
+          configuration
+              .getKubernetesClient()
+              .orElseGet(
+                  () -> controllerConfiguration.getConfigurationService().getKubernetesClient());
     }
     return targetClient;
   }


### PR DESCRIPTION
InformerManager is generic over C extends Informable, but getTargetClient
type-tested for InformerEventSourceConfiguration to find out whether a specific
(e.g. remote cluster) client was configured. Informable has two implementors
and only one could answer the question, so a third configuration type wanting
its own client would be ignored silently rather than failing to compile.

Move the default getKubernetesClient() up from InformerEventSourceConfiguration
to Informable and let InformerManager ask the configuration directly. The
default still returns Optional.empty(), so existing implementations are
unaffected. As a side effect the ConfigurationService client is now only
created when no specific client is configured, instead of being created and
then discarded.


---

Quality-only change: no intended behavior difference. Cut from `next` and
touches a disjoint set of files from the sibling cleanup PRs, so it can be merged
independently and in any order.

Verified on this branch alone: `mvn -o -pl operator-framework-core,operator-framework-junit -am test`
(693 core + 6 junit tests, no failures) and `mvn spotless:check`.
