### PR TITLE
chore: remove the JavaPoet dependency

### DIFF
--- a/operator-framework/pom.xml
+++ b/operator-framework/pom.xml
@@ -41,11 +41,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.squareup</groupId>
-      <artifactId>javapoet</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/ControllerConfigurationAnnotationProcessor.java
+++ b/operator-framework/src/main/java/io/javaoperatorsdk/operator/config/runtime/ControllerConfigurationAnnotationProcessor.java
@@ -34,8 +34,6 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 
-import com.squareup.javapoet.TypeName;
-
 import static io.javaoperatorsdk.operator.config.runtime.RuntimeControllerMetadata.RECONCILERS_RESOURCE_PATH;
 
 @SupportedAnnotationTypes("io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration")
@@ -103,9 +101,12 @@ public class ControllerConfigurationAnnotationProcessor extends AbstractProcesso
                 + "': ignoring!");
         return;
       }
-      final TypeName customResourceType = TypeName.get(resourceType);
+      // the resolved resource type is always a declared type, so its element is a TypeElement
+      final var customResourceType =
+          (TypeElement) processingEnv.getTypeUtils().asElement(resourceType);
       controllersResourceWriter.add(
-          controllerClassSymbol.getQualifiedName().toString(), customResourceType.toString());
+          controllerClassSymbol.getQualifiedName().toString(),
+          customResourceType.getQualifiedName().toString());
 
     } catch (Exception ioException) {
       log.error("Error", ioException);

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/config/runtime/ControllerConfigurationAnnotationProcessorTest.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/config/runtime/ControllerConfigurationAnnotationProcessorTest.java
@@ -15,6 +15,9 @@
  */
 package io.javaoperatorsdk.operator.config.runtime;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 import javax.tools.StandardLocation;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +28,7 @@ import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
 
 import static io.javaoperatorsdk.operator.config.runtime.RuntimeControllerMetadata.RECONCILERS_RESOURCE_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ControllerConfigurationAnnotationProcessorTest {
 
@@ -71,6 +75,26 @@ class ControllerConfigurationAnnotationProcessorTest {
   }
 
   /**
+   * When the reconciled resource is itself generic, the resolved type is a parameterized {@code
+   * DeclaredType}. Only its erasure may be written to the mapping resource: {@link
+   * ClassMappingProvider} loads the recorded name with {@code ClassUtils.getClass(String)}, which
+   * cannot parse type arguments.
+   */
+  @Test
+  public void writesErasureOfGenericResourceType() {
+    Compilation compilation =
+        Compiler.javac()
+            .withProcessors(new ControllerConfigurationAnnotationProcessor())
+            .compile(
+                JavaFileObjects.forResource("compile-fixtures/GenericResourceReconciler.java"));
+    CompilationSubject.assertThat(compilation).succeeded();
+    assertMapping(
+        compilation,
+        "io.GenericResourceReconciler,io.GenericResourceReconciler.MyGenericCustomResource");
+    assertLoadableMapping(compilation);
+  }
+
+  /**
    * Checks that the generated mapping resource contains the expected {@code
    * reconciler,resource-class} line, using the same fully qualified, dot separated names that
    * {@link ClassMappingProvider} expects to be able to load at runtime.
@@ -80,5 +104,41 @@ class ControllerConfigurationAnnotationProcessorTest {
         .generatedFile(StandardLocation.CLASS_OUTPUT, RECONCILERS_RESOURCE_PATH)
         .contentsAsUtf8String()
         .contains(expectedMapping);
+  }
+
+  /**
+   * Checks that every recorded name in the generated mapping resource is a plain binary-ish class
+   * name, i.e. one that {@code ClassUtils.getClass(String)} can actually resolve, rather than a
+   * generic type signature such as {@code io.Foo<java.lang.String>}.
+   */
+  private static void assertLoadableMapping(Compilation compilation) {
+    final var contents =
+        compilation
+            .generatedFile(StandardLocation.CLASS_OUTPUT, RECONCILERS_RESOURCE_PATH)
+            .map(
+                file -> {
+                  try {
+                    return file.getCharContent(true).toString();
+                  } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                })
+            .orElseThrow(() -> new AssertionError("no mapping resource was generated"));
+    contents
+        .lines()
+        .filter(line -> !line.isBlank())
+        .forEach(
+            line -> {
+              final var names = line.split(",");
+              assertThat(names).as("mapping line '%s'", line).hasSize(2);
+              for (String name : names) {
+                assertThat(name)
+                    .as("recorded class name '%s' must be loadable at runtime", name)
+                    .doesNotContain("<")
+                    .doesNotContain(">")
+                    .doesNotContain(" ")
+                    .matches("[\\p{L}_$][\\p{L}\\p{N}_$]*(\\.[\\p{L}_$][\\p{L}\\p{N}_$]*)*");
+              }
+            });
   }
 }

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/config/runtime/ControllerConfigurationAnnotationProcessorTest.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/config/runtime/ControllerConfigurationAnnotationProcessorTest.java
@@ -15,12 +15,16 @@
  */
 package io.javaoperatorsdk.operator.config.runtime;
 
+import javax.tools.StandardLocation;
+
 import org.junit.jupiter.api.Test;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.CompilationSubject;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
+
+import static io.javaoperatorsdk.operator.config.runtime.RuntimeControllerMetadata.RECONCILERS_RESOURCE_PATH;
 
 class ControllerConfigurationAnnotationProcessorTest {
 
@@ -33,6 +37,9 @@ class ControllerConfigurationAnnotationProcessorTest {
                 JavaFileObjects.forResource(
                     "compile-fixtures/ReconcilerImplemented2Interfaces.java"));
     CompilationSubject.assertThat(compilation).succeeded();
+    assertMapping(
+        compilation,
+        "io.ReconcilerImplemented2Interfaces,io.ReconcilerImplemented2Interfaces.MyCustomResource");
   }
 
   @Test
@@ -45,6 +52,9 @@ class ControllerConfigurationAnnotationProcessorTest {
                 JavaFileObjects.forResource(
                     "compile-fixtures/ReconcilerImplementedIntermediateAbstractClass.java"));
     CompilationSubject.assertThat(compilation).succeeded();
+    assertMapping(
+        compilation,
+        "io.ReconcilerImplementedIntermediateAbstractClass,io.AbstractReconciler.MyCustomResource");
   }
 
   @Test
@@ -57,5 +67,18 @@ class ControllerConfigurationAnnotationProcessorTest {
                 JavaFileObjects.forResource("compile-fixtures/MultilevelAbstractReconciler.java"),
                 JavaFileObjects.forResource("compile-fixtures/MultilevelReconciler.java"));
     CompilationSubject.assertThat(compilation).succeeded();
+    assertMapping(compilation, "io.MultilevelReconciler,io.MultilevelReconciler.MyCustomResource");
+  }
+
+  /**
+   * Checks that the generated mapping resource contains the expected {@code
+   * reconciler,resource-class} line, using the same fully qualified, dot separated names that
+   * {@link ClassMappingProvider} expects to be able to load at runtime.
+   */
+  private static void assertMapping(Compilation compilation, String expectedMapping) {
+    CompilationSubject.assertThat(compilation)
+        .generatedFile(StandardLocation.CLASS_OUTPUT, RECONCILERS_RESOURCE_PATH)
+        .contentsAsUtf8String()
+        .contains(expectedMapping);
   }
 }

--- a/operator-framework/src/test/resources/compile-fixtures/GenericResourceReconciler.java
+++ b/operator-framework/src/test/resources/compile-fixtures/GenericResourceReconciler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Java Operator SDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+
+/**
+ * The reconciled resource is itself a generic type, so the resolved resource type is a
+ * parameterized {@code DeclaredType}. Only its erasure can be written to the mapping resource,
+ * because that is the only form {@code ClassMappingProvider} is able to load at runtime.
+ */
+@ControllerConfiguration
+public class GenericResourceReconciler implements
+    Reconciler<GenericResourceReconciler.MyGenericCustomResource<String>> {
+
+  public static class MyGenericCustomResource<S> extends CustomResource<S, Void> {
+  }
+
+  @Override
+  public UpdateControl<MyGenericCustomResource<String>> reconcile(
+      MyGenericCustomResource<String> customResource,
+      Context<MyGenericCustomResource<String>> context) {
+    return UpdateControl.noUpdate();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
     <mokito.version>5.23.0</mokito.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <compile-testing.version>0.23.0</compile-testing.version>
-    <javapoet.version>1.13.0</javapoet.version>
     <assertj.version>3.27.7</assertj.version>
     <awaitility.version>4.3.0</awaitility.version>
     <spring-boot.version>2.7.3</spring-boot.version>
@@ -147,11 +146,6 @@
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-core</artifactId>
         <version>${micrometer-core.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup</groupId>
-        <artifactId>javapoet</artifactId>
-        <version>${javapoet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>


### PR DESCRIPTION
JavaPoet was only used in ControllerConfigurationAnnotationProcessor to turn
the resolved resource TypeMirror into its fully qualified name, which the
standard annotation processing API can do on its own: the resolved type is
always a declared type, so its element is a TypeElement and its qualified name
is exactly the dot separated name ClassMappingProvider loads at runtime.

JavaPoet has not been released since 2024, which makes it unusable for users
whose organizations do not approve unmaintained dependencies.

Also assert the content of the generated mapping resource in the processor
tests, which previously only checked that compilation succeeded and so could
not have caught a wrong resource class name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated reconciler-to-resource mappings for interface, abstract-base, multilevel, and generic resource hierarchies.
  * Ensured mappings consistently record loadable, fully qualified resource type names, including erased generic types.

* **Tests**
  * Added compilation checks covering generated mappings across supported hierarchy and generic-resource scenarios.

* **Chores**
  * Removed an unused build dependency and related project configuration, with no user-facing API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->