### PR TITLE
improve: fix misleading useSecondaryToPrimaryIndex method name

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/InformerEventSource.java
@@ -70,7 +70,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
         configuration);
     // If there is a primary to secondary mapper there is no need for primary to secondary index.
     primaryToSecondaryMapper = configuration.getPrimaryToSecondaryMapper();
-    if (useSecondaryToPrimaryIndex()) {
+    if (usePrimaryToSecondaryIndex()) {
       primaryToSecondaryIndex =
           // The index uses the secondary to primary mapper (always present) to build the index
           new DefaultPrimaryToSecondaryIndex<>(configuration.getSecondaryToPrimaryMapper());
@@ -236,7 +236,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
   @Override
   public Set<R> getSecondaryResources(P primary) {
     Set<ResourceID> secondaryIDs;
-    if (useSecondaryToPrimaryIndex()) {
+    if (usePrimaryToSecondaryIndex()) {
       var primaryResourceID = ResourceID.fromResource(primary);
       secondaryIDs = primaryToSecondaryIndex.getSecondaryResources(primaryResourceID);
       log.debug(
@@ -281,7 +281,7 @@ public class InformerEventSource<R extends HasMetadata, P extends HasMetadata>
     return relatedPrimaryIds;
   }
 
-  private boolean useSecondaryToPrimaryIndex() {
+  private boolean usePrimaryToSecondaryIndex() {
     return this.primaryToSecondaryMapper == null;
   }
 


### PR DESCRIPTION
Signed-off-by: Attila Mészáros <a_meszaros@apple.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal index selection for informer event source lookups.
  * Ensured secondary-resource lookups continue to work when no primary-to-secondary mapper is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->