### PR TITLE
improve: log informer re-use on info level

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/DefaultInformerPool.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/DefaultInformerPool.java
@@ -66,7 +66,7 @@ public class DefaultInformerPool extends AbstractInformerPool {
                         existing.informerListLimit(),
                         classifier.informerListLimit()));
         var referenceCount = pooled.referenceCount().incrementAndGet();
-        log.debug(
+        log.info(
             "Reusing pooled informer for classifier: {}. Reference count now: {}. Requested by"
                 + " controller: {}, event source: {}",
             classifier,


### PR DESCRIPTION
This seems to be an important enough information to log on startup.

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
