### PR TITLE
improve: patch for event recorder count to use resource from context

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/DefaultEventSink.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/DefaultEventSink.java
@@ -60,7 +60,7 @@ public class DefaultEventSink implements EventSink {
               .withLastTimestamp(event.getLastTimestamp())
               .withMessage(event.getMessage())
               .build();
-      events.withName(name).patch(aggregated);
+      events.resource(existing).patch(aggregated);
     }
   }
 }


### PR DESCRIPTION
This avoids reading the resource again from cluster

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event updates to detect conflicts when multiple operations attempt to modify the same event concurrently.
  * Prevented stale event data from overwriting newer changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->