### PR TITLE
refactor: configurable event recorder

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RegisteredController.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/RegisteredController.java
@@ -18,7 +18,6 @@ package io.javaoperatorsdk.operator;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.NamespaceChangeable;
-import io.javaoperatorsdk.operator.api.event.EventRecorder;
 import io.javaoperatorsdk.operator.health.ControllerHealthInfo;
 
 public interface RegisteredController<P extends HasMetadata> extends NamespaceChangeable {
@@ -26,17 +25,4 @@ public interface RegisteredController<P extends HasMetadata> extends NamespaceCh
   ControllerConfiguration<P> getConfiguration();
 
   ControllerHealthInfo getControllerHealthInfo();
-
-  /**
-   * Returns the {@link EventRecorder} of this controller, to record Kubernetes events outside of a
-   * reconciliation, for example from a status listener or a background task. Within a
-   * reconciliation, use {@link io.javaoperatorsdk.operator.api.reconciler.Context#eventRecorder()}
-   * instead.
-   *
-   * @return the event recorder associated with this controller
-   */
-  default EventRecorder eventRecorder() {
-    throw new UnsupportedOperationException(
-        "This implementation of RegisteredController does not provide an EventRecorder");
-  }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
@@ -35,6 +35,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.javaoperatorsdk.operator.api.event.DefaultEventRecorder;
+import io.javaoperatorsdk.operator.api.event.EventRecorder;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.Experimental;
@@ -293,6 +294,25 @@ public interface ConfigurationService {
    */
   default String clusterScopedEventNamespace() {
     return DefaultEventRecorder.CLUSTER_SCOPED_EVENT_NAMESPACE;
+  }
+
+  /**
+   * The {@link EventRecorder} the controllers of the operator record their Kubernetes events
+   * through, to plug in a custom implementation, for example one that assembles events differently
+   * by extending {@link DefaultEventRecorder}, or one that records them somewhere else entirely.
+   *
+   * <p>When empty, which is the default, every controller gets a {@link DefaultEventRecorder} of
+   * its own, which attributes the events it records to that controller. A recorder configured here
+   * is shared by all controllers of the operator, so it decides on its own what the events it
+   * records are attributed to, and it is up to the caller to hold on to the instance if it also
+   * records events outside of a reconciliation.
+   *
+   * @return the event recorder to use for the whole operator, or an empty optional to let each
+   *     controller use its own default one
+   */
+  @Experimental(Experimental.API_MIGHT_CHANGE)
+  default Optional<EventRecorder> eventRecorder() {
+    return Optional.empty();
   }
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationService.java
@@ -302,10 +302,9 @@ public interface ConfigurationService {
    * by extending {@link DefaultEventRecorder}, or one that records them somewhere else entirely.
    *
    * <p>When empty, which is the default, every controller gets a {@link DefaultEventRecorder} of
-   * its own, which attributes the events it records to that controller. A recorder configured here
-   * is shared by all controllers of the operator, so it decides on its own what the events it
-   * records are attributed to, and it is up to the caller to hold on to the instance if it also
-   * records events outside of a reconciliation.
+   * its own. A recorder configured here is shared by all controllers of the operator instead, which
+   * is why the reconciliation an event is recorded from is passed to it per call rather than
+   * configured on it: implementations have to be stateless and thread safe.
    *
    * @return the event recorder to use for the whole operator, or an empty optional to let each
    *     controller use its own default one

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
+import io.javaoperatorsdk.operator.api.event.EventRecorder;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.Experimental;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
@@ -48,6 +49,7 @@ public class ConfigurationServiceOverrider {
   private ExecutorService workflowExecutorService;
   private LeaderElectionConfiguration leaderElectionConfiguration;
   private String clusterScopedEventNamespace;
+  private EventRecorder eventRecorder;
   private InformerStoppedHandler informerStoppedHandler;
   private Boolean stopOnInformerErrorDuringStartup;
   private Duration cacheSyncTimeout;
@@ -145,6 +147,25 @@ public class ConfigurationServiceOverrider {
    */
   public ConfigurationServiceOverrider withClusterScopedEventNamespace(String namespace) {
     this.clusterScopedEventNamespace = namespace;
+    return this;
+  }
+
+  /**
+   * Replaces the {@link EventRecorder} the controllers of the operator record their Kubernetes
+   * events through by the specified one, which is then shared by all of them. Use this to record
+   * events differently, for example through a subclass of {@link
+   * io.javaoperatorsdk.operator.api.event.DefaultEventRecorder} that assembles them another way, or
+   * to hold on to the recorder in order to also record events outside of a reconciliation.
+   *
+   * <p>When not set, every controller records its events through a recorder of its own, which
+   * attributes them to that controller.
+   *
+   * @param eventRecorder the event recorder to use for the whole operator
+   * @return this {@link ConfigurationServiceOverrider} for chained customization
+   */
+  @Experimental(Experimental.API_MIGHT_CHANGE)
+  public ConfigurationServiceOverrider withEventRecorder(EventRecorder eventRecorder) {
+    this.eventRecorder = eventRecorder;
     return this;
   }
 
@@ -295,6 +316,11 @@ public class ConfigurationServiceOverrider {
         return clusterScopedEventNamespace != null
             ? clusterScopedEventNamespace
             : original.clusterScopedEventNamespace();
+      }
+
+      @Override
+      public Optional<EventRecorder> eventRecorder() {
+        return eventRecorder != null ? Optional.of(eventRecorder) : original.eventRecorder();
       }
 
       @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverrider.java
@@ -155,7 +155,7 @@ public class ConfigurationServiceOverrider {
    * events through by the specified one, which is then shared by all of them. Use this to record
    * events differently, for example through a subclass of {@link
    * io.javaoperatorsdk.operator.api.event.DefaultEventRecorder} that assembles them another way, or
-   * to hold on to the recorder in order to also record events outside of a reconciliation.
+   * by delegating to another system (e.g. emitting events to an external store).
    *
    * <p>When not set, every controller records its events through a recorder of its own, which
    * attributes them to that controller.

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/DefaultEventRecorder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/DefaultEventRecorder.java
@@ -33,6 +33,8 @@ import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
+import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import static java.util.Objects.requireNonNullElse;
 
@@ -71,50 +73,46 @@ public class DefaultEventRecorder implements EventRecorder {
 
   private static final int IDENTITY_HASH_LENGTH = 32;
 
-  private final String reportingController;
-  private final String reportingInstance;
-  private final String clusterScopedEventNamespace;
   private final EventSink sink;
 
-  public DefaultEventRecorder(
-      String reportingController, String reportingInstance, EventSink sink) {
-    this(reportingController, reportingInstance, CLUSTER_SCOPED_EVENT_NAMESPACE, sink);
-  }
-
-  public DefaultEventRecorder(
-      String reportingController,
-      String reportingInstance,
-      String clusterScopedEventNamespace,
-      EventSink sink) {
-    this.reportingController = reportingController;
-    this.reportingInstance = reportingInstance;
-    this.clusterScopedEventNamespace = clusterScopedEventNamespace;
+  public DefaultEventRecorder(EventSink sink) {
     this.sink = sink;
   }
 
   /**
    * The instance name to report events under, when it is not otherwise configured. Uses the host
    * name, which for an operator running in a pod is the pod name.
+   *
+   * <p>Resolved once and cached: it cannot change over the life of the process, and looking the
+   * host name up can hit the name service, which is not something to do on every recorded event.
    */
   public static String defaultReportingInstance() {
-    var fromEnv = System.getenv("HOSTNAME");
-    if (fromEnv != null && !fromEnv.isBlank()) {
-      return fromEnv;
-    }
-    try {
-      return InetAddress.getLocalHost().getHostName();
-    } catch (UnknownHostException e) {
-      log.debug("Could not determine host name to report events under", e);
-      return "unknown";
+    return DefaultReportingInstance.VALUE;
+  }
+
+  private static final class DefaultReportingInstance {
+    private static final String VALUE = resolve();
+
+    private static String resolve() {
+      var fromEnv = System.getenv("HOSTNAME");
+      if (fromEnv != null && !fromEnv.isBlank()) {
+        return fromEnv;
+      }
+      try {
+        return InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException e) {
+        log.debug("Could not determine host name to report events under", e);
+        return "unknown";
+      }
     }
   }
 
   @Override
-  public void record(HasMetadata regarding, EventRecord event) {
-    Objects.requireNonNull(regarding, "the object the event is about must not be null");
+  public void record(EventRecord event, Context<?> context) {
+    Objects.requireNonNull(context, "the context of the reconciliation must not be null");
     Objects.requireNonNull(event, "event must not be null");
     try {
-      sink.emit(toEvent(regarding, event));
+      sink.emit(toEvent(context, event), context);
     } catch (Exception e) {
       // recording an event must never break the caller: a controller that fails to reconcile
       // because it could not write an event is strictly worse than one that records nothing
@@ -122,26 +120,28 @@ public class DefaultEventRecorder implements EventRecorder {
           "Could not record {} event with reason {} for resource {} in namespace {}",
           event.type(),
           event.reason(),
-          regarding.getMetadata().getName(),
-          regarding.getMetadata().getNamespace(),
+          context.getPrimaryResource().getMetadata().getName(),
+          context.getPrimaryResource().getMetadata().getNamespace(),
           e);
     }
   }
 
   @Override
-  public ResourceEventRecorder forResource(HasMetadata regarding) {
-    Objects.requireNonNull(regarding, "the object events will be about must not be null");
-    return new BoundEventRecorder(this, regarding);
+  public ResourceEventRecorder forContext(Context<?> context) {
+    Objects.requireNonNull(context, "the context events will be recorded from must not be null");
+    return new BoundEventRecorder(this, context);
   }
 
-  protected Event toEvent(HasMetadata regarding, EventRecord record) {
+  protected Event toEvent(Context<?> context, EventRecord record) {
+    var controllerName = context.getControllerConfiguration().getName();
+    var regarding = context.getPrimaryResource();
     var now = Instant.now().truncatedTo(ChronoUnit.SECONDS).toString();
     var involvedObject = objectReferenceFor(regarding);
     var builder =
         new EventBuilder()
             .withNewMetadata()
-            .withName(eventName(regarding, record))
-            .withNamespace(eventNamespace(regarding))
+            .withName(eventName(regarding, record, controllerName))
+            .withNamespace(eventNamespace(regarding, context))
             .withLabels(record.labels())
             .withAnnotations(record.annotations())
             .endMetadata()
@@ -152,19 +152,33 @@ public class DefaultEventRecorder implements EventRecorder {
             .withFirstTimestamp(now)
             .withLastTimestamp(now)
             .withCount(1)
-            .withReportingComponent(record.reportingComponent().orElse(reportingController))
-            .withReportingInstance(reportingInstance)
+            .withReportingComponent(record.reportingComponent().orElse(controllerName))
+            .withReportingInstance(
+                context
+                    .getControllerConfiguration()
+                    .getConfigurationService()
+                    .getLeaderElectionConfiguration()
+                    .flatMap(LeaderElectionConfiguration::getIdentity)
+                    .orElseGet(DefaultEventRecorder::defaultReportingInstance))
             // the deprecated source is still what kubectl renders in the "From" column
             .withNewSource()
-            .withComponent(record.reportingComponent().orElse(reportingController))
+            .withComponent(record.reportingComponent().orElse(controllerName))
             .endSource();
     record.action().ifPresent(builder::withAction);
     return builder.build();
   }
 
-  private String eventNamespace(HasMetadata regarding) {
+  private String eventNamespace(HasMetadata regarding, Context<?> context) {
     var namespace = regarding.getMetadata().getNamespace();
-    return namespace == null ? clusterScopedEventNamespace : namespace;
+    if (namespace != null) {
+      return namespace;
+    }
+    return requireNonNullElse(
+        context
+            .getControllerConfiguration()
+            .getConfigurationService()
+            .clusterScopedEventNamespace(),
+        CLUSTER_SCOPED_EVENT_NAMESPACE);
   }
 
   /**
@@ -177,7 +191,7 @@ public class DefaultEventRecorder implements EventRecorder {
    * <p>The object is identified by its uid, with the kind as a fallback for objects that do not
    * have one yet, such as a dependent resource that has only been built so far.
    */
-  private String eventName(HasMetadata regarding, EventRecord record) {
+  private String eventName(HasMetadata regarding, EventRecord record, String reportingController) {
     var metadata = regarding.getMetadata();
     var identity =
         String.join(
@@ -234,22 +248,22 @@ public class DefaultEventRecorder implements EventRecorder {
         .build();
   }
 
-  private record BoundEventRecorder(EventRecorder delegate, HasMetadata regarding)
+  private record BoundEventRecorder(EventRecorder delegate, Context<?> context)
       implements ResourceEventRecorder {
 
     @Override
     public void normal(String reason, String message) {
-      record(EventRecord.normal(reason, message));
+      delegate.record(EventRecord.normal(reason, message), context);
     }
 
     @Override
     public void warn(String reason, String message) {
-      record(EventRecord.warning(reason, message));
+      delegate.record(EventRecord.warning(reason, message), context);
     }
 
     @Override
     public void record(EventRecord event) {
-      delegate.record(regarding, event);
+      delegate.record(event, context);
     }
   }
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/DefaultEventSink.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/DefaultEventSink.java
@@ -18,6 +18,7 @@ package io.javaoperatorsdk.operator.api.event;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import static java.util.Objects.requireNonNullElse;
 
@@ -47,7 +48,7 @@ public class DefaultEventSink implements EventSink {
   }
 
   @Override
-  public void emit(Event event) {
+  public void emit(Event event, Context<?> context) {
     var events = client.v1().events().inNamespace(event.getMetadata().getNamespace());
     var name = event.getMetadata().getName();
     var existing = events.withName(name).get();

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/EventRecorder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/EventRecorder.java
@@ -15,7 +15,7 @@
  */
 package io.javaoperatorsdk.operator.api.event;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.Experimental;
 
 import static io.javaoperatorsdk.operator.api.reconciler.Experimental.API_MIGHT_CHANGE;
@@ -23,13 +23,16 @@ import static io.javaoperatorsdk.operator.api.reconciler.Experimental.API_MIGHT_
 /**
  * Records Kubernetes events on behalf of a controller.
  *
- * <p>This is the unbound form of the API: it is scoped to a controller, not to a reconciliation,
- * and can therefore be used outside of the reconciliation loop, for example from a status listener
- * or a background task. To use it that way, configure the instance the operator records its events
- * through, see {@link io.javaoperatorsdk.operator.api.config.ConfigurationService#eventRecorder()},
- * and keep a reference to it. Within a reconciliation, prefer {@link
+ * <p>This is the unbound form of the API: an instance is shared by all the controllers of the
+ * operator, and everything that varies between them - the primary resource an event is about, the
+ * controller the event is attributed to, and the configuration the event is assembled from - is
+ * passed per call, as the {@link Context} of the reconciliation recording the event.
+ * Implementations are therefore expected to be stateless and thread safe. To record events through
+ * an implementation of your own, see {@link
+ * io.javaoperatorsdk.operator.api.config.ConfigurationService#eventRecorder()}. Within a
+ * reconciliation, prefer {@link
  * io.javaoperatorsdk.operator.api.reconciler.Context#eventRecorder()}, which is already bound to
- * the primary resource.
+ * the context.
  *
  * <p>Recording an event is best effort: failures to write the event to the cluster are logged and
  * swallowed, and never fail the caller.
@@ -38,20 +41,20 @@ import static io.javaoperatorsdk.operator.api.reconciler.Experimental.API_MIGHT_
 public interface EventRecorder {
 
   /**
-   * Records an event about the given object.
+   * Records an event about the primary resource of the given reconciliation.
    *
-   * @param regarding the object the event is about; it will be referenced as the involved object of
-   *     the resulting event
    * @param event the event to record
+   * @param context the context of the reconciliation recording the event; the event is about its
+   *     primary resource and is attributed to its controller
    */
-  void record(HasMetadata regarding, EventRecord event);
+  void record(EventRecord event, Context<?> context);
 
   /**
-   * Returns a view of this recorder bound to the given object, so that the object doesn't have to
-   * be passed for every event.
+   * Returns a view of this recorder bound to the given reconciliation, so that the context doesn't
+   * have to be passed for every event.
    *
-   * @param regarding the object subsequent events will be about
-   * @return a recorder bound to {@code regarding}
+   * @param context the context subsequent events will be recorded from
+   * @return a recorder bound to {@code context}
    */
-  ResourceEventRecorder forResource(HasMetadata regarding);
+  ResourceEventRecorder forContext(Context<?> context);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/EventRecorder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/EventRecorder.java
@@ -16,20 +16,25 @@
 package io.javaoperatorsdk.operator.api.event;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.reconciler.Experimental;
+
+import static io.javaoperatorsdk.operator.api.reconciler.Experimental.API_MIGHT_CHANGE;
 
 /**
  * Records Kubernetes events on behalf of a controller.
  *
  * <p>This is the unbound form of the API: it is scoped to a controller, not to a reconciliation,
  * and can therefore be used outside of the reconciliation loop, for example from a status listener
- * or a background task. Obtain it from {@link
- * io.javaoperatorsdk.operator.RegisteredController#eventRecorder()}. Within a reconciliation,
- * prefer {@link io.javaoperatorsdk.operator.api.reconciler.Context#eventRecorder()}, which is
- * already bound to the primary resource.
+ * or a background task. To use it that way, configure the instance the operator records its events
+ * through, see {@link io.javaoperatorsdk.operator.api.config.ConfigurationService#eventRecorder()},
+ * and keep a reference to it. Within a reconciliation, prefer {@link
+ * io.javaoperatorsdk.operator.api.reconciler.Context#eventRecorder()}, which is already bound to
+ * the primary resource.
  *
  * <p>Recording an event is best effort: failures to write the event to the cluster are logged and
  * swallowed, and never fail the caller.
  */
+@Experimental(API_MIGHT_CHANGE)
 public interface EventRecorder {
 
   /**

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/EventSink.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/EventSink.java
@@ -16,6 +16,7 @@
 package io.javaoperatorsdk.operator.api.event;
 
 import io.fabric8.kubernetes.api.model.Event;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 /**
  * Writes fully built events somewhere. Extracted from {@link EventRecorder} so that the assembly of
@@ -29,7 +30,11 @@ public interface EventSink {
   /**
    * Delivers the event.
    *
-   * @param event the event to deliver
+   * @param event the event to deliver, fully assembled: everything the event says is already built
+   *     into it
+   * @param context the context of the reconciliation the event was recorded from, for
+   *     implementations that route the event based on it rather than on its contents. Ignored by
+   *     {@link DefaultEventSink}.
    */
-  void emit(Event event);
+  void emit(Event event, Context<?> context);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/EventSink.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/EventSink.java
@@ -17,6 +17,9 @@ package io.javaoperatorsdk.operator.api.event;
 
 import io.fabric8.kubernetes.api.model.Event;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.Experimental;
+
+import static io.javaoperatorsdk.operator.api.reconciler.Experimental.API_MIGHT_CHANGE;
 
 /**
  * Writes fully built events somewhere. Extracted from {@link EventRecorder} so that the assembly of
@@ -36,5 +39,6 @@ public interface EventSink {
    *     implementations that route the event based on it rather than on its contents. Ignored by
    *     {@link DefaultEventSink}.
    */
+  @Experimental(API_MIGHT_CHANGE)
   void emit(Event event, Context<?> context);
 }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/ResourceEventRecorder.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/event/ResourceEventRecorder.java
@@ -15,6 +15,10 @@
  */
 package io.javaoperatorsdk.operator.api.event;
 
+import io.javaoperatorsdk.operator.api.reconciler.Experimental;
+
+import static io.javaoperatorsdk.operator.api.reconciler.Experimental.API_MIGHT_CHANGE;
+
 /**
  * An {@link EventRecorder} bound to a single object, typically the primary resource of the current
  * reconciliation.
@@ -22,6 +26,7 @@ package io.javaoperatorsdk.operator.api.event;
  * <p>Recording an event is best effort: failures to write the event to the cluster are logged and
  * swallowed, and never fail the caller.
  */
+@Experimental(API_MIGHT_CHANGE)
 public interface ResourceEventRecorder {
 
   /** Records a {@link EventType#NORMAL} event about the bound object. */

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
@@ -216,8 +216,9 @@ public interface Context<P extends HasMetadata> {
 
   /**
    * Returns a {@link ResourceEventRecorder} bound to the primary resource, to record Kubernetes
-   * events about it. To record events outside of a reconciliation, or about another object, use
-   * {@link io.javaoperatorsdk.operator.RegisteredController#eventRecorder()}.
+   * events about it. To record events outside of a reconciliation, or about another object, use an
+   * {@link io.javaoperatorsdk.operator.api.event.EventRecorder} configured for the operator, see
+   * {@link io.javaoperatorsdk.operator.api.config.ConfigurationService#eventRecorder()}.
    *
    * @return an event recorder bound to the primary resource
    * @throws UnsupportedOperationException if the implementation does not provide an event recorder

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/Context.java
@@ -215,10 +215,9 @@ public interface Context<P extends HasMetadata> {
   ResourceOperations<P> resourceOperations();
 
   /**
-   * Returns a {@link ResourceEventRecorder} bound to the primary resource, to record Kubernetes
-   * events about it. To record events outside of a reconciliation, or about another object, use an
-   * {@link io.javaoperatorsdk.operator.api.event.EventRecorder} configured for the operator, see
-   * {@link io.javaoperatorsdk.operator.api.config.ConfigurationService#eventRecorder()}.
+   * Returns a {@link ResourceEventRecorder} bound to this context, to record Kubernetes events
+   * about the primary resource. To record them through an implementation of your own, see {@link
+   * io.javaoperatorsdk.operator.api.config.ConfigurationService#eventRecorder()}.
    *
    * @return an event recorder bound to the primary resource
    * @throws UnsupportedOperationException if the implementation does not provide an event recorder

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/api/reconciler/DefaultContext.java
@@ -211,7 +211,7 @@ public class DefaultContext<P extends HasMetadata> implements Context<P> {
 
   @Override
   public ResourceEventRecorder eventRecorder() {
-    return controller.eventRecorder().forResource(primaryResource);
+    return controller.eventRecorder().forContext(this);
   }
 
   @Override

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -36,6 +36,7 @@ import io.javaoperatorsdk.operator.CustomResourceUtils;
 import io.javaoperatorsdk.operator.MissingCRDException;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.RegisteredController;
+import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.ExecutorServiceManager;
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
@@ -115,15 +116,19 @@ public class Controller<P extends HasMetadata>
     this.kubernetesClient = kubernetesClient;
     this.metrics = Optional.ofNullable(configurationService.getMetrics()).orElse(Metrics.NOOP);
     this.eventRecorder =
-        new DefaultEventRecorder(
-            configuration.getName(),
-            configurationService
-                .getLeaderElectionConfiguration()
-                .flatMap(LeaderElectionConfiguration::getIdentity)
-                .orElseGet(DefaultEventRecorder::defaultReportingInstance),
-            Optional.ofNullable(configurationService.clusterScopedEventNamespace())
-                .orElse(DefaultEventRecorder.CLUSTER_SCOPED_EVENT_NAMESPACE),
-            new DefaultEventSink(kubernetesClient));
+        configurationService
+            .eventRecorder()
+            .orElseGet(
+                () ->
+                    new DefaultEventRecorder(
+                        configuration.getName(),
+                        configurationService
+                            .getLeaderElectionConfiguration()
+                            .flatMap(LeaderElectionConfiguration::getIdentity)
+                            .orElseGet(DefaultEventRecorder::defaultReportingInstance),
+                        Optional.ofNullable(configurationService.clusterScopedEventNamespace())
+                            .orElse(DefaultEventRecorder.CLUSTER_SCOPED_EVENT_NAMESPACE),
+                        new DefaultEventSink(kubernetesClient)));
     contextInitializer = reconciler instanceof ContextInitializer;
     isCleaner = reconciler instanceof Cleaner;
 
@@ -358,7 +363,11 @@ public class Controller<P extends HasMetadata>
     return controllerHealthInfo;
   }
 
-  @Override
+  /**
+   * The {@link EventRecorder} this controller records its Kubernetes events through, either the one
+   * configured for the operator, see {@link ConfigurationService#eventRecorder()}, or a {@link
+   * DefaultEventRecorder} of its own.
+   */
   public EventRecorder eventRecorder() {
     return eventRecorder;
   }

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -36,7 +36,6 @@ import io.javaoperatorsdk.operator.CustomResourceUtils;
 import io.javaoperatorsdk.operator.MissingCRDException;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.RegisteredController;
-import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.ExecutorServiceManager;
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/Controller.java
@@ -38,7 +38,6 @@ import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.RegisteredController;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.ExecutorServiceManager;
-import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
 import io.javaoperatorsdk.operator.api.config.workflow.WorkflowSpec;
 import io.javaoperatorsdk.operator.api.event.DefaultEventRecorder;
 import io.javaoperatorsdk.operator.api.event.DefaultEventSink;
@@ -117,17 +116,7 @@ public class Controller<P extends HasMetadata>
     this.eventRecorder =
         configurationService
             .eventRecorder()
-            .orElseGet(
-                () ->
-                    new DefaultEventRecorder(
-                        configuration.getName(),
-                        configurationService
-                            .getLeaderElectionConfiguration()
-                            .flatMap(LeaderElectionConfiguration::getIdentity)
-                            .orElseGet(DefaultEventRecorder::defaultReportingInstance),
-                        Optional.ofNullable(configurationService.clusterScopedEventNamespace())
-                            .orElse(DefaultEventRecorder.CLUSTER_SCOPED_EVENT_NAMESPACE),
-                        new DefaultEventSink(kubernetesClient)));
+            .orElseGet(() -> new DefaultEventRecorder(new DefaultEventSink(kubernetesClient)));
     contextInitializer = reconciler instanceof ContextInitializer;
     isCleaner = reconciler instanceof Cleaner;
 

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverriderTest.java
@@ -23,6 +23,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.event.EventRecord;
+import io.javaoperatorsdk.operator.api.event.EventRecorder;
+import io.javaoperatorsdk.operator.api.event.ResourceEventRecorder;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,6 +107,28 @@ class ConfigurationServiceOverriderTest {
         config.getInformerStoppedHandler(), overridden.getLeaderElectionConfiguration());
     assertNotEquals(
         config.reconciliationTerminationTimeout(), overridden.reconciliationTerminationTimeout());
+  }
+
+  @Test
+  void eventRecorderIsNotConfiguredByDefaultAndCanBeOverridden() {
+    final var eventRecorder =
+        new EventRecorder() {
+          @Override
+          public void record(HasMetadata regarding, EventRecord event) {}
+
+          @Override
+          public ResourceEventRecorder forResource(HasMetadata regarding) {
+            return null;
+          }
+        };
+
+    assertThat(config.eventRecorder()).isEmpty();
+    assertThat(
+            new ConfigurationServiceOverrider(config)
+                .withEventRecorder(eventRecorder)
+                .build()
+                .eventRecorder())
+        .contains(eventRecorder);
   }
 
   @Test

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverriderTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.event.DefaultEventRecorder;
 import io.javaoperatorsdk.operator.api.event.EventRecord;
 import io.javaoperatorsdk.operator.api.event.EventRecorder;
 import io.javaoperatorsdk.operator.api.event.ResourceEventRecorder;
@@ -143,5 +144,17 @@ class ConfigurationServiceOverriderTest {
         .isEqualTo(13);
     assertThat(((ThreadPoolExecutor) overridden.getWorkflowExecutorService()).getMaximumPoolSize())
         .isEqualTo(14);
+  }
+
+  @Test
+  void clusterScopedEventNamespaceDefaultsToTheDefaultNamespaceAndCanBeOverridden() {
+    assertThat(config.clusterScopedEventNamespace())
+        .isEqualTo(DefaultEventRecorder.CLUSTER_SCOPED_EVENT_NAMESPACE);
+    assertThat(
+            new ConfigurationServiceOverrider(config)
+                .withClusterScopedEventNamespace("operator-ns")
+                .build()
+                .clusterScopedEventNamespace())
+        .isEqualTo("operator-ns");
   }
 }

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverriderTest.java
@@ -27,6 +27,7 @@ import io.javaoperatorsdk.operator.api.event.EventRecord;
 import io.javaoperatorsdk.operator.api.event.EventRecorder;
 import io.javaoperatorsdk.operator.api.event.ResourceEventRecorder;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -114,10 +115,10 @@ class ConfigurationServiceOverriderTest {
     final var eventRecorder =
         new EventRecorder() {
           @Override
-          public void record(HasMetadata regarding, EventRecord event) {}
+          public void record(EventRecord event, Context<?> context) {}
 
           @Override
-          public ResourceEventRecorder forResource(HasMetadata regarding) {
+          public ResourceEventRecorder forContext(Context<?> context) {
             return null;
           }
         };

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/event/DefaultEventRecorderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/event/DefaultEventRecorderTest.java
@@ -17,18 +17,26 @@ package io.javaoperatorsdk.operator.api.event;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 
+import static io.javaoperatorsdk.operator.api.config.LeaderElectionConfigurationBuilder.aLeaderElectionConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DefaultEventRecorderTest {
 
@@ -37,11 +45,11 @@ class DefaultEventRecorderTest {
 
   private final List<Event> emitted = new ArrayList<>();
   private final DefaultEventRecorder recorder =
-      new DefaultEventRecorder(CONTROLLER, INSTANCE, emitted::add);
+      new DefaultEventRecorder((event, context) -> emitted.add(event));
 
   @Test
   void fillsInEverythingDerivableFromTheControllerAndTheInvolvedObject() {
-    recorder.record(configMap(), EventRecord.warning("Failed", "could not do the thing"));
+    recorder.record(EventRecord.warning("Failed", "could not do the thing"), context(configMap()));
 
     assertThat(emitted).hasSize(1);
     var event = emitted.get(0);
@@ -64,8 +72,34 @@ class DefaultEventRecorderTest {
   }
 
   @Test
+  void takesTheReportingControllerFromTheControllerConfigurationOfTheContext() {
+    var context = context(configMap());
+    when(context.getControllerConfiguration().getName()).thenReturn("othercontroller");
+
+    recorder.record(EventRecord.normal("Created", "created"), context);
+
+    assertThat(emitted.get(0).getReportingComponent()).isEqualTo("othercontroller");
+    assertThat(emitted.get(0).getSource().getComponent()).isEqualTo("othercontroller");
+  }
+
+  @Test
+  void fallsBackToTheHostNameWhenLeaderElectionConfiguresNoIdentity() {
+    var context = context(configMap());
+    when(context
+            .getControllerConfiguration()
+            .getConfigurationService()
+            .getLeaderElectionConfiguration())
+        .thenReturn(Optional.empty());
+
+    recorder.record(EventRecord.normal("Created", "created"), context);
+
+    assertThat(emitted.get(0).getReportingInstance())
+        .isEqualTo(DefaultEventRecorder.defaultReportingInstance());
+  }
+
+  @Test
   void createsTheEventInTheNamespaceOfTheInvolvedObject() {
-    recorder.record(configMap(), EventRecord.normal("Created", "created"));
+    recorder.record(EventRecord.normal("Created", "created"), context(configMap()));
 
     assertThat(emitted.get(0).getMetadata().getNamespace()).isEqualTo("ns1");
     assertThat(emitted.get(0).getMetadata().getName()).startsWith("test1.");
@@ -73,7 +107,7 @@ class DefaultEventRecorderTest {
 
   @Test
   void recordsEventsForClusterScopedObjectsInTheDefaultNamespace() {
-    recorder.record(clusterScoped(), EventRecord.normal("Created", "created"));
+    recorder.record(EventRecord.normal("Created", "created"), context(clusterScoped()));
 
     assertThat(emitted.get(0).getMetadata().getNamespace())
         .isEqualTo(DefaultEventRecorder.CLUSTER_SCOPED_EVENT_NAMESPACE);
@@ -82,18 +116,15 @@ class DefaultEventRecorderTest {
 
   @Test
   void clusterScopedEventNamespaceCanBeOverridden() {
-    var configured = new DefaultEventRecorder(CONTROLLER, INSTANCE, "operator-ns", emitted::add);
-
-    configured.record(clusterScoped(), EventRecord.normal("Created", "created"));
+    recorder.record(
+        EventRecord.normal("Created", "created"), context(clusterScoped(), "operator-ns"));
 
     assertThat(emitted.get(0).getMetadata().getNamespace()).isEqualTo("operator-ns");
   }
 
   @Test
   void anOverriddenClusterScopedNamespaceDoesNotAffectNamespacedResources() {
-    var configured = new DefaultEventRecorder(CONTROLLER, INSTANCE, "operator-ns", emitted::add);
-
-    configured.record(configMap(), EventRecord.normal("Created", "created"));
+    recorder.record(EventRecord.normal("Created", "created"), context(configMap(), "operator-ns"));
 
     assertThat(emitted.get(0).getMetadata().getNamespace()).isEqualTo("ns1");
   }
@@ -101,13 +132,13 @@ class DefaultEventRecorderTest {
   @Test
   void perEventReportingComponentOverridesTheControllerName() {
     recorder.record(
-        configMap(),
         EventRecord.builder()
             .reason("Submitted")
             .message("submitted")
             .reportingComponent("JobManagerDeployment")
             .action("Submit")
-            .build());
+            .build(),
+        context(configMap()));
 
     assertThat(emitted.get(0).getReportingComponent()).isEqualTo("JobManagerDeployment");
     assertThat(emitted.get(0).getSource().getComponent()).isEqualTo("JobManagerDeployment");
@@ -119,13 +150,13 @@ class DefaultEventRecorderTest {
   @Test
   void passesLabelsAndAnnotationsThrough() {
     recorder.record(
-        configMap(),
         EventRecord.builder()
             .reason("Scaling")
             .message("scaling up")
             .label("group", "autoscaler")
             .annotation("recommendation", "4")
-            .build());
+            .build(),
+        context(configMap()));
 
     assertThat(emitted.get(0).getMetadata().getLabels()).containsEntry("group", "autoscaler");
     assertThat(emitted.get(0).getMetadata().getAnnotations()).containsEntry("recommendation", "4");
@@ -135,19 +166,29 @@ class DefaultEventRecorderTest {
   void aFailingSinkNeverFailsTheCaller() {
     var failing =
         new DefaultEventRecorder(
-            CONTROLLER,
-            INSTANCE,
-            event -> {
+            (event, context) -> {
               throw new RuntimeException("API server said no");
             });
 
-    assertThatCode(() -> failing.record(configMap(), EventRecord.normal("Created", "created")))
+    assertThatCode(
+            () -> failing.record(EventRecord.normal("Created", "created"), context(configMap())))
         .doesNotThrowAnyException();
   }
 
   @Test
-  void boundRecorderRecordsAboutTheBoundObject() {
-    var bound = recorder.forResource(configMap());
+  void passesTheContextOnToTheSink() {
+    var contexts = new ArrayList<Context<?>>();
+    var recording = new DefaultEventRecorder((event, context) -> contexts.add(context));
+    var context = context(configMap());
+
+    recording.record(EventRecord.normal("Created", "created"), context);
+
+    assertThat(contexts).containsExactly(context);
+  }
+
+  @Test
+  void boundRecorderRecordsAboutThePrimaryResourceOfTheBoundContext() {
+    var bound = recorder.forContext(context(configMap()));
 
     bound.normal("Created", "created");
     bound.warn("Failed", "failed");
@@ -170,7 +211,7 @@ class DefaultEventRecorderTest {
             .endMetadata()
             .build();
 
-    recorder.record(configMap, EventRecord.normal("Created", "created"));
+    recorder.record(EventRecord.normal("Created", "created"), context(configMap));
 
     var name = emitted.get(0).getMetadata().getName();
     assertThat(name).hasSizeLessThanOrEqualTo(253);
@@ -187,7 +228,7 @@ class DefaultEventRecorderTest {
 
   @Test
   void namesEventsWithADnsSafeHashSuffix() {
-    recorder.record(configMap(), EventRecord.normal("Created", "created"));
+    recorder.record(EventRecord.normal("Created", "created"), context(configMap()));
 
     assertThat(emitted.get(0).getMetadata().getName()).matches("test1\\.[0-9a-f]{32}");
   }
@@ -200,12 +241,41 @@ class DefaultEventRecorderTest {
     // name and the sink would take the second for a repeat of the first and drop it.
     assertThat("Aa".hashCode()).isEqualTo("BB".hashCode());
 
-    recorder.record(configMap(), EventRecord.warning("Failed", "Aa"));
-    recorder.record(configMap(), EventRecord.warning("Failed", "BB"));
+    recorder.record(EventRecord.warning("Failed", "Aa"), context(configMap()));
+    recorder.record(EventRecord.warning("Failed", "BB"), context(configMap()));
 
     assertThat(emitted).hasSize(2);
     assertThat(emitted.get(0).getMetadata().getName())
         .isNotEqualTo(emitted.get(1).getMetadata().getName());
+  }
+
+  Context<?> context(HasMetadata primaryResource) {
+    return context(primaryResource, DefaultEventRecorder.CLUSTER_SCOPED_EVENT_NAMESPACE);
+  }
+
+  /**
+   * The recorder reads everything it does not get from the {@link EventRecord} off the context: the
+   * primary resource the event is about, the name of the controller the event is attributed to, and
+   * the configuration service the reporting instance and the cluster scoped event namespace come
+   * from.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  Context<?> context(HasMetadata primaryResource, String clusterScopedEventNamespace) {
+    var configurationService = mock(ConfigurationService.class);
+    when(configurationService.getLeaderElectionConfiguration())
+        .thenReturn(
+            Optional.of(aLeaderElectionConfiguration("lease").withIdentity(INSTANCE).build()));
+    when(configurationService.clusterScopedEventNamespace())
+        .thenReturn(clusterScopedEventNamespace);
+
+    ControllerConfiguration controllerConfiguration = mock(ControllerConfiguration.class);
+    when(controllerConfiguration.getName()).thenReturn(CONTROLLER);
+    when(controllerConfiguration.getConfigurationService()).thenReturn(configurationService);
+
+    Context context = mock(Context.class);
+    when(context.getPrimaryResource()).thenReturn(primaryResource);
+    when(context.getControllerConfiguration()).thenReturn(controllerConfiguration);
+    return context;
   }
 
   ConfigMap configMap() {

--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/ControllerTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/processing/ControllerTest.java
@@ -28,6 +28,8 @@ import io.javaoperatorsdk.operator.api.config.BaseConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.MockControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.workflow.WorkflowSpec;
+import io.javaoperatorsdk.operator.api.event.DefaultEventRecorder;
+import io.javaoperatorsdk.operator.api.event.EventRecorder;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.Cleaner;
 import io.javaoperatorsdk.operator.api.reconciler.DefaultContext;
@@ -108,6 +110,36 @@ class ControllerTest {
     // e.g. leader election enabled: event sources start but event processing is deferred.
     controller.start(false);
     verify(metrics, never()).eventProcessingStarted(controller);
+  }
+
+  @Test
+  void recordsEventsThroughTheEventRecorderConfiguredForTheOperator() {
+    final var client = MockKubernetesClient.client(Secret.class);
+    final var eventRecorder = mock(EventRecorder.class);
+    final var configurationService =
+        ConfigurationService.newOverriddenConfigurationService(
+            new BaseConfigurationService(),
+            o -> o.withEventRecorder(eventRecorder).withKubernetesClient(client));
+    final var configuration =
+        MockControllerConfiguration.forResource(Secret.class, configurationService);
+
+    final var controller = new Controller<Secret>(reconciler, configuration, client);
+
+    assertThat(controller.eventRecorder()).isSameAs(eventRecorder);
+  }
+
+  @Test
+  void recordsEventsThroughAnEventRecorderOfItsOwnWhenNoneIsConfigured() {
+    final var client = MockKubernetesClient.client(Secret.class);
+    final var configuration =
+        MockControllerConfiguration.forResource(
+            Secret.class,
+            ConfigurationService.newOverriddenConfigurationService(
+                new BaseConfigurationService(), o -> o.withKubernetesClient(client)));
+
+    final var controller = new Controller<Secret>(reconciler, configuration, client);
+
+    assertThat(controller.eventRecorder()).isInstanceOf(DefaultEventRecorder.class);
   }
 
   @Test

--- a/operator-framework/src/test/java/io/javaoperatorsdk/operator/config/loader/ConfigLoaderTest.java
+++ b/operator-framework/src/test/java/io/javaoperatorsdk/operator/config/loader/ConfigLoaderTest.java
@@ -123,6 +123,19 @@ class ConfigLoaderTest {
   }
 
   @Test
+  void applyConfigsAppliesStrings() {
+    var loader =
+        new ConfigLoader(
+            mapProvider(Map.of("josdk.events.cluster-scoped-namespace", "operator-ns")));
+
+    var base = new BaseConfigurationService(null);
+    var result =
+        ConfigurationService.newOverriddenConfigurationService(base, loader.applyConfigs());
+
+    assertThat(result.clusterScopedEventNamespace()).isEqualTo("operator-ns");
+  }
+
+  @Test
   void applyConfigsOnlyAppliesPresentKeys() {
     // Only one key present — other defaults must be unchanged.
     var loader =


### PR DESCRIPTION
Makes the low level API stateless, that allows to easily replace the underlying implementation. Also marks the APIs experimental.
