### PR TITLE
improve: simplify log message for informer re-use

### DIFF
--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/DefaultInformerPool.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/DefaultInformerPool.java
@@ -67,12 +67,11 @@ public class DefaultInformerPool extends AbstractInformerPool {
                         classifier.informerListLimit()));
         var referenceCount = pooled.referenceCount().incrementAndGet();
         log.info(
-            "Reusing pooled informer for classifier: {}. Reference count now: {}. Requested by"
-                + " controller: {}, event source: {}",
-            classifier,
-            referenceCount,
-            controllerName,
-            name);
+            "Reusing pooled informer for classifier: {}. Reference count: {}",
+            classifier.resourceClass() == null
+                ? classifier.groupVersionKind()
+                : classifier.resourceClass(),
+            referenceCount);
       }
     }
     return informer;

--- a/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/DefaultInformerPool.java
+++ b/operator-framework-core/src/main/java/io/javaoperatorsdk/operator/processing/event/source/informer/pool/DefaultInformerPool.java
@@ -67,7 +67,7 @@ public class DefaultInformerPool extends AbstractInformerPool {
                         classifier.informerListLimit()));
         var referenceCount = pooled.referenceCount().incrementAndGet();
         log.info(
-            "Reusing pooled informer for classifier: {}. Reference count: {}",
+            "Reusing pooled informer for resource type: {}. Reference count: {}",
             classifier.resourceClass() == null
                 ? classifier.groupVersionKind()
                 : classifier.resourceClass(),


### PR DESCRIPTION
The atual log message was unnecessary verbose and hard to read / follow. 

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
