### PR TITLE
test: cover the remaining ConfigurationServiceOverrider settings

### DIFF
--- a/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverriderTest.java
+++ b/operator-framework-core/src/test/java/io/javaoperatorsdk/operator/api/config/ConfigurationServiceOverriderTest.java
@@ -17,13 +17,17 @@ package io.javaoperatorsdk.operator.api.config;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.junit.jupiter.api.Test;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -98,10 +102,10 @@ class ConfigurationServiceOverriderTest {
     assertNotEquals(config.getExecutorService(), overridden.getExecutorService());
     assertNotEquals(config.getWorkflowExecutorService(), overridden.getWorkflowExecutorService());
     assertNotEquals(config.getMetrics(), overridden.getMetrics());
+    assertNotEquals(config.getResourceCloner(), overridden.getResourceCloner());
     assertNotEquals(
         config.getLeaderElectionConfiguration(), overridden.getLeaderElectionConfiguration());
-    assertNotEquals(
-        config.getInformerStoppedHandler(), overridden.getLeaderElectionConfiguration());
+    assertNotEquals(config.getInformerStoppedHandler(), overridden.getInformerStoppedHandler());
     assertNotEquals(
         config.reconciliationTerminationTimeout(), overridden.reconciliationTerminationTimeout());
   }
@@ -117,5 +121,31 @@ class ConfigurationServiceOverriderTest {
         .isEqualTo(13);
     assertThat(((ThreadPoolExecutor) overridden.getWorkflowExecutorService()).getMaximumPoolSize())
         .isEqualTo(14);
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Test
+  void dependentResourceFactoryDefaultsToTheSharedOneAndCanBeOverridden() {
+    final var factory = new DependentResourceFactory() {};
+
+    assertThat(config.dependentResourceFactory()).isSameAs(DependentResourceFactory.DEFAULT);
+    assertThat(
+            new ConfigurationServiceOverrider(config)
+                .withDependentResourceFactory(factory)
+                .build()
+                .dependentResourceFactory())
+        .isSameAs(factory);
+  }
+
+  @Test
+  void defaultNonSSAResourcesDefaultToConfigMapsAndSecretsAndCanBeOverridden() {
+    assertThat(config.defaultNonSSAResources())
+        .containsExactlyInAnyOrder(ConfigMap.class, Secret.class);
+    assertThat(
+            new ConfigurationServiceOverrider(config)
+                .withDefaultNonSSAResource(Set.of())
+                .build()
+                .defaultNonSSAResources())
+        .isEmpty();
   }
 }


### PR DESCRIPTION
overrideShouldWork asserted the informer stopped handler override against
getLeaderElectionConfiguration(), so it passed whatever the overrider did with the
handler, and set a resource cloner it never asserted. Fixes both, and adds coverage
for withDependentResourceFactory and withDefaultNonSSAResource, neither of which was
exercised anywhere.

withDependentResourceFactory had no coverage at all: unlike the scalar setters, it is
not reachable through a ConfigLoader binding, so
operatorBindingsCoverAllSingleScalarSettersOnConfigurationServiceOverrider does not
guard it either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration override validation for informer stopped handlers.
  * Added coverage ensuring resource cloner overrides are honored.

* **Tests**
  * Added verification for default and customizable dependent resource factories.
  * Added verification for default non-server-side-applied resource types and their ability to be overridden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->