### PR TITLE
improve: exclude sample from release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -642,21 +642,21 @@
               <tokenAuth>true</tokenAuth>
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
-            </configuration>
-            <!-- The samples are demos and end-to-end tests, not artifacts to depend on, so they
+              <!-- The samples are demos and end-to-end tests, not artifacts to depend on, so they
                    are not published. The Kotlin one could not be published anyway: it has no Java
                    sources, so no javadoc jar is attached to it and Central rejects the whole
                    deployment with "Javadocs must be provided but not found in entries". -->
-            <excludeArtifacts>
-              <excludeArtifact>sample-operators</excludeArtifact>
-              <excludeArtifact>sample-controller-namespace-deletion</excludeArtifact>
-              <excludeArtifact>sample-kotlin-operator</excludeArtifact>
-              <excludeArtifact>sample-leader-election</excludeArtifact>
-              <excludeArtifact>sample-mysql-schema-operator</excludeArtifact>
-              <excludeArtifact>sample-operations</excludeArtifact>
-              <excludeArtifact>sample-tomcat-operator</excludeArtifact>
-              <excludeArtifact>sample-webpage-operator</excludeArtifact>
-            </excludeArtifacts>
+              <excludeArtifacts>
+                <excludeArtifact>sample-operators</excludeArtifact>
+                <excludeArtifact>sample-controller-namespace-deletion</excludeArtifact>
+                <excludeArtifact>sample-kotlin-operator</excludeArtifact>
+                <excludeArtifact>sample-leader-election</excludeArtifact>
+                <excludeArtifact>sample-mysql-schema-operator</excludeArtifact>
+                <excludeArtifact>sample-operations</excludeArtifact>
+                <excludeArtifact>sample-tomcat-operator</excludeArtifact>
+                <excludeArtifact>sample-webpage-operator</excludeArtifact>
+              </excludeArtifacts>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -643,6 +643,20 @@
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
             </configuration>
+            <!-- The samples are demos and end-to-end tests, not artifacts to depend on, so they
+                   are not published. The Kotlin one could not be published anyway: it has no Java
+                   sources, so no javadoc jar is attached to it and Central rejects the whole
+                   deployment with "Javadocs must be provided but not found in entries". -->
+            <excludeArtifacts>
+              <excludeArtifact>sample-operators</excludeArtifact>
+              <excludeArtifact>sample-controller-namespace-deletion</excludeArtifact>
+              <excludeArtifact>sample-kotlin-operator</excludeArtifact>
+              <excludeArtifact>sample-leader-election</excludeArtifact>
+              <excludeArtifact>sample-mysql-schema-operator</excludeArtifact>
+              <excludeArtifact>sample-operations</excludeArtifact>
+              <excludeArtifact>sample-tomcat-operator</excludeArtifact>
+              <excludeArtifact>sample-webpage-operator</excludeArtifact>
+            </excludeArtifacts>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Signed-off-by: Attila Mészáros <a_meszaros@apple.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Sample operator artifacts are no longer published to Maven Central.
  * This includes demo and end-to-end testing samples, including the Kotlin sample.
  * Release publishing now consistently excludes these eight sample artifacts, keeping Maven Central focused on supported release components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->