### PR TITLE
chore(ci): test against Kubernetes 1.37, drop EOL 1.32 and 1.33

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         # Use the latest versions supported by minikube, otherwise GitHub it will
         # end up in a throttling requests from minikube and workflow will fail.
         # Minikube does such requests only if a version is not officially supported.
-        kubernetes: [ 'v1.32.13', 'v1.33.9', 'v1.34.5', 'v1.35.2' ]
+        kubernetes: [ 'v1.34.11', 'v1.35.8', 'v1.36.4', 'v1.37.0' ]
     uses: ./.github/workflows/integration-tests.yml
     with:
       java-version: ${{ matrix.java }}
@@ -27,7 +27,7 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       java-version: 25
-      kube-version: 'v1.35.2'
+      kube-version: 'v1.37.0'
       http-client: ${{ matrix.httpclient }}
       experimental: true
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.18.0
         with:
-          minikube version: 'v1.38.1'
+          minikube version: 'v1.39.0'
           # Use the latest versions supported by minikube, otherwise GitHub it will
           # end up in a throttling requests from minikube and workflow will fail.
           # Minikube does such requests only if a version is not officially supported.
-          kubernetes version: 'v1.35.2'
+          kubernetes version: 'v1.37.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Minikube
         uses: manusa/actions-setup-minikube@v2.18.0
         with:
-          minikube version: 'v1.38.1'
+          minikube version: 'v1.39.0'
           kubernetes version: '${{ inputs.kube-version }}'
           github token: ${{ github.token }}
 


### PR DESCRIPTION
Bump minikube to v1.39.0 (newest supported Kubernetes version is v1.37.0)
and update the tested Kubernetes versions to the four currently supported
upstream minors: 1.34, 1.35, 1.36 and 1.37.
